### PR TITLE
Introduce Publication Throttling

### DIFF
--- a/up-l2/dispatchers/README.adoc
+++ b/up-l2/dispatchers/README.adoc
@@ -30,13 +30,13 @@ SPDX-License-Identifier: Apache-2.0
 ----
 
 
-Like IP packets, uProtocol messages (CE) have a source attribute (originator of the message) and sink attribute (where should the message be sent to). These attributes are used to route the CEs from one uE to the next if the destination is not the receiving uE.
+Like IP packets, uProtocol messages (UMessages) have a source attribute (originator of the message) and sink attribute (where should the message be sent to). These attributes are used to route the UMessages from one uE to the next if the destination is not the receiving uE. For more information about these and other uProtocol attributes, please refer to link:../../basics/uattributes.adoc[UAttributes].
 
 NOTE: Dispatcher and router shall be used For the remainder of this document we will use the term dispatcher and router interchangeably.
 
-The header contains information for routing as well as metadata (of the data). One of the core principles of uProtocol is that the data portion of CE *MUST* be untouched by message routers, this is very similar to how most Internet standards work today. Only the source who generated the CE and the sink who will consume the CE needs to understand/analyze the payload of the CE.
+The header contains information for routing as well as metadata (of the data). One of the core principles of uProtocol is that the data portion of UMessage *MUST* be untouched by dispatchers, this is very similar to how most Internet standards work today. Only the source who generated the UMessages and the sink who will consume the UMessages needs to understand/analyze the payload of the UMessage (UPayload).
 
-To be able to forward/dispatch/route CEs through the network, we must define specific purpose built uEs to perform these tasks (ex. Ethernet switches, IP routers, etc...). Platform uEs that are responsible for event dispatching and implementing the communication layer are described in the sections below. We will elaborate on these specific uEs in the Platform uEs section below.
+To be able to forward/dispatch/route UMessages through the network, we must define specific purpose built uEs to perform these tasks (ex. Ethernet switches, IP routers, etc...). Platform uEs that are responsible for event dispatching and implementing the communication layer are described in the sections below. We will elaborate on these specific uEs in the Platform uEs section below.
 
 .Dispatchers
 [width=100%",cols="30%,70%"]
@@ -44,81 +44,74 @@ To be able to forward/dispatch/route CEs through the network, we must define spe
 |Dispatcher uEs | Description
 
 |*uBus*
-|Message bus that dispatches CEs between uEs over a common transport. It provides multicast and forwarding functionality (works like a network switch)
+a|Local message bus responsible for dispatches messages between uEs within a uPlatform (uDevice namespace) using the same uTransport. Depending on the implementation, the uBus could either be implemented by the uTransport itself (e.g. zenoh based uPlatforms) or implemented in a standalone service (e.g. Android uPlatform)
 
 |*uStreamer*
-|Provides Device-2-Device CE routing either using the same or different transport protocols , i.e. when events need to move form one transport to the next it flows through the streamer (can be equated to an IP router)
+|Device-2-Device (uPlatform to uPlatform) message routing that over either the same or different uTransport
 
 |*Cloud Gateway*
 |A uE that sits at the edge of the cloud to connect non-cloud devices (ex. vehicles, phones, etc...) to the cloud
 
 |*Device Proxy Router (DPR)*
-|A uE that proxies CEs between devices that are not able to directly communicate with each other
+|A uE that proxies messages between devices that are not able to directly communicate with each other
 |===
 
 .Dispatchers
 image::dispatchers.drawio.svg[Dispatchers]
+
 
 == Requirements
 In this section we will elaborate on the requirements of the platform Dispatchers (uBus, uStreamer, etc...) and their role in message delivery. Dispatchers build upon the transport layer delivery requirement assumptions.
 
 NOTE: These communication layer requirements are still for point-2-point uE communication to and from a dispatcher
 
-* *MUST* support At-least-once delivery policy, this means that the dispatcher will make every attempt to dispatch the CE to the intended Receiver
-  ** *MUST* queue CEs not successfully acknowledged (transport level at-least-once delivery confirmation described above)
-  ** *MUST* attempt to retry transmission of the CE. Retry policy is specific to the dispatcher implementation
-  ** Dispatcher *MUST NOT* discard CEs unless either CE has expired (CE.ttl), or the egress queue is full. CEs that cannot be delivered are sent to a Dead Letter Office Topic
+* *MUST* support At-least-once delivery policy, this means that the dispatcher will make every attempt to dispatch the message to the intended receiver
+  ** *MUST* queue messages not successfully acknowledged (transport level at-least-once delivery confirmation described above)
+  ** *MUST* attempt to retry transmission of the message. Retry policy is specific to the dispatcher implementation
+  ** Dispatcher *MUST NOT* discard message unless either the message has expired (see https://github.com/eclipse-uprotocol/uprotocol-core-api/blob/main/src/main/proto/uattributes.proto[`UAttribute:ttl`] for more details), or the egress queue is full. Messages that cannot be delivered are sent to a Dead Letter Office Topic (DLT)
 
-* *MAY* support additional CE delivery policies in general or per topic in the future
+NOTE: Implementation of the DLT is uPlatform specific and is not covered in this document 
+
+* *MAY* support additional message delivery policies in general or per topic in the future
 * *SHOULD* dispatch in order that it received the CE
 * *MAY* batch CEs when delivering to the Receiver
 * CEs that cannot be delivered *MUST* be sent to the Dead Letter topic (DLT)
-  ** DLT *MUST* include at least the CE header, SHOULD contain the full CE
-  ** DLT *MUST* include the reason for the failed delivery attempt using  error codes defined in google.rpc.Code
-  ** uEs MUST be able to subscribe to the DLT to be notified of message deliver failures
+  ** DLT *MUST* include at least the message header, *SHOULD* contain the full Message
+  ** DLT *MUST* include the reason for the failed delivery attempt using per https://github.com/eclipse-uprotocol/uprotocol-core-api/blob/main/src/main/proto/ustatus.proto[UStatus] error codes
+  ** uEs *SHOULD* be able to subscribe to the DLT to be notified of message deliver failures
 
 If the uP-L1 delivery method is push:
 
-* *SHALL* provide an API to start/stop dispatching of CEs per-topic, this is to avoid having to queue CEs on the Receiver if the Receiver is not ready to receive the CEs
+* *SHOULD* provide an API to start/stop dispatching of messages per-topic, this is to avoid having to queue messages on the Receiver if the Receiver is not ready to receive
 
 
 == RPC Error Handling
 
-When a dispatcher is unable to dispatch an event for a given reason (queue full, etc...), the dispatcher is responsible to generate an RPC Response message and send it to the originator of the request. The status code is populated in the  link:../messages/v1/README.adoc#_response_message[`commstatus`] attribute of the response message using the <<commstatus-codes>> defined below.
+When a dispatcher is unable to dispatch an event for a given reason (e.g. queue full, etc...), the dispatcher is responsible to generate an RPC Response message and send it to the originator of the request. The status code is populated in the  link:../messages/v1/README.adoc#_response_message[`commstatus`] attribute of the response message using the error codes defined in https://github.com/eclipse-uprotocol/uprotocol-core-api/blob/main/src/main/proto/ustatus.proto[UCode].
 
-.commstatus Codes
-[#commstatus-codes]
-[width="100%",cols="30%,60%",options="header",]
-!===
-|*google.rpc.Code* |*Reason*
 
-|`*UNAVAILABLE*`
-|The req.v1 has expired due to the downstream uE was unavailable (ex. uDevice was disconnected). uE that issued the req.v1 MAY retry with back-off
-
-|`*DEADLINE_EXCEEDED*`
-|CE has timed out per the ttl attribute specifications defined in req.v1 event
-
-|`*PERMISSION_DENIED*`
-|source is not permitted to access sink
-
-|`*UNAUTHENTICATED*`
-|source does not have valid authentication credentials (ex. uE's identity does not match the source attribute)
-
-|`*RESOURCE_EXHAUSTED*`
-|The dispatcher ran out of resources (buffer full)
-
-|`*INVALID_ARGUMENT*`
-|Invalid CE header attributes not covered above (ex. any mal-formatted attributes)
-
-|`*UNKNOWN*`
-|An unknown (but not critical) error has occurred
-
-|`*INTERNAL*`
-|There is a serious error has occurred not described by error codes mentioned above
-!===
 
 <<rpc-error-flow>> figure below illustrates the sequence of messages for RPC flows and the role dispatchers play in error handling.
 
 .RPC Error Flow
 [#rpc-error-flow]
 image::rpc_flow.png[RPC Error Handling]
+
+
+=== uStreamer Throttling of Published Messages
+
+Throttling is the act of reducing the publication frequency of messages published between devices. A subscriber might want to throttle publishations to reduce network bandwidth costs (e.g. cloud app subscribing to vehicle topics like GPS location). 
+
+A subscriber uses  `max_frequency` attribute of https://github.com/eclipse-uprotocol/uprotocol-core-api/blob/main/src/main/proto/core/usubscription/v3/usubscription.proto#L121[SubscribeAttributes] message to set the desired maximum publication frequency (value in Hertz), this attribute is only considered for remote topics. 
+
+
+* *MUST* only forward published messages at the `max_frequency`
+
+If messages are received at a higher frequency than `max_frequency`:
+
+* *MUST* be dropped by the uStreamer
+* Dropped messages *MUST NOT* be added to the DLT
+
+if `max_frequency` is not set or the frequency is less than the publisher's frequency:
+
+* *MUST* not throttle messages

--- a/up-l3/usubscription/v2/README.adoc
+++ b/up-l3/usubscription/v2/README.adoc
@@ -218,7 +218,9 @@ image::unsub_local.svg[Unsubscribe Local Flow]
 .Remote Unsubscribe Flow
 image::unsub_remote.svg[Unsubscribe Remote Flow]
 
-* uSubscription *MUST* change the subscriber to itself (core.usubscription) when unsubscribing to remote topics 
+* uSubscription *MUST* change the subscriber to itself (core.usubscription) when unsubscribing to remote topics
+
+* Updates to SubscribeAttributes (ex. changes to `max_frequency`) *MUST* be sent as Update notification to the remote device
 
 === Topic Deprecation
 


### PR DESCRIPTION
The following adds to uStreamer and uSubscription the ability to throttle published events when we send them between devices. Example use is cloud application subscribing to high frequency topics like GPS location.

#24