### PR TITLE
Distributed tracing

### DIFF
--- a/basics/cloudevents.adoc
+++ b/basics/cloudevents.adoc
@@ -218,6 +218,11 @@ otherwise:
 * Attribute *MAY* be present
 * When not present, or value is 0, message *MUST NOT* time out
 
+|`traceparent`
+|`traceparent`
+|String
+|*O*
+| Contains a version, trace ID, span ID, and trace options as defined in https://w3c.github.io/trace-context/#traceparent-header[section 3.2].  Intended to be compatible with https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md[CloudEvents distributed tracing extension].
 
 |===
 

--- a/up-l2/dispatchers/README.adoc
+++ b/up-l2/dispatchers/README.adoc
@@ -76,6 +76,7 @@ NOTE: These communication layer requirements are still for point-2-point uE comm
   ** DLT *MUST* include at least the CE header, SHOULD contain the full CE
   ** DLT *MUST* include the reason for the failed delivery attempt using  error codes defined in google.rpc.Code
   ** uEs MUST be able to subscribe to the DLT to be notified of message deliver failures
+* *MUST* forward attributes from the CE header
 
 If the uP-L1 delivery method is push:
 


### PR DESCRIPTION
Define optional uAttribute (`traceparent`) that is compatible with the [CloudEvents Distributed Tracing extension](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md) and industry norms to support proper end-to-end observability. This is especially valuable for [more complex situations](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md#using-the-distributed-tracing-extension).  One example could be where a UE may raise an event as a result of another event.

Example: 
1. Vehicle's session service publishes an `trip started` event (id=`abc123`)
2. A driver app receives the event, looks up driver's identity, and D.O.T. log to see first drive of the day.  Driver app publishes `shift_started` event (id=`xyz456`, traceparent=`abc123`)
3. When an issue arises, the operational team can quickly and effectively see the correlated chain of events

For discussion: would we also want to include an optional `tracestate` to be more [complete](https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md#tracestate)?

#49 