### PR TITLE
MQTT5 Protocol spec

### DIFF
--- a/up-l1/mqtt.adoc
+++ b/up-l1/mqtt.adoc
@@ -35,8 +35,85 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
 
 For more information, please refer to https://mqtt.org/
 
-
 == Specifications
 
+=== UAttribute Mapping
 
-_Coming Soon_
+MQTT 5 supports custom header fields, and we leverage this to map certain UAttribute values into the MQTT header.
+
+[cols="1,1"]
+|===
+| MQTT Header Property Code | Value (key:value)
+| UserProperty
+| ("upriority","{UAttribute.priority}")
+| CorrelationData
+| "{UAttribute.reqId}"
+| UserProperty
+| ("sink","{UAttribute.sink}") # Should this be serialized to MicroUri?
+|===
+
+The upriority field is needed as mqtt's QoS is very limited, so this will allow listeners to prioritize messages.
+
+The Correlation Data Property Code contains the request correlation id.
+
+The sink field is used to correctly map a message to the correct uE as the topic name may not contain all of the information.
+
+=== URI Mapping
+
+Depending on whether the UURI is local or remote, the MQTT Topic that the message will be published on will be different:
+
+* The remote UUri (with UAuthority): `UUri.UAthority.name`
+* The local UUri (without UAuthority): `UUri.UEntity/UUri.UResource`
+
+Examples:
+
+* The remote UUri (with UAuthority):
+
+[source]
+----
+UUri {
+  authority: UAuthority {
+    name: "Vehicle_1",
+    number: Id({01, 02, 03, 10, 11, 12})
+  },
+  entity: UEntity {
+    name: "body.access",
+    version_major: 1,
+    id: 1234,
+  }
+  resource: UResource {
+    name: "door",
+    instance: "front_left",
+    message: "Door",
+    id: 5678,
+  }
+}
+----
+
+Since this is a remote UUri, the MQTT Topic will simply be `Vehicle_1`.
+
+* The local UUri (without UAuthority):
+
+[source]
+----
+UUri {
+  authority: empty,
+  entity: UEntity {
+    name: "body.access",
+    version_major: 1,
+    id: 1234,
+  }
+  resource: UResource {
+    name: "door",
+    instance: "front_left",
+    message: "Door",
+    id: 5678,
+  }
+}
+----
+
+Since this is a local UUri, the MQTT Topic will be constructed from the UEnity name and the UResource name `body.access/door`.
+
+=== Payload Encoding
+
+The MQTT payload **MUST** be a UMessage that is represented as a byte array to reduce size.

--- a/up-l1/mqtt.adoc
+++ b/up-l1/mqtt.adoc
@@ -62,8 +62,8 @@ The sink field is used to correctly map a message to the correct uE as the topic
 
 Depending on whether the UURI is local or remote, the MQTT Topic that the message will be published on will be different:
 
-* The remote UUri (with UAuthority): `UUri.UAthority.name`
-* The local UUri (without UAuthority): `UUri.UEntity/UUri.UResource`
+* The remote UUri (with UAuthority): `upr/UUri.UAthority.name`
+* The local UUri (without UAuthority): `upl/UUri.UEntity/UUri.UResource`
 
 Examples:
 
@@ -90,7 +90,7 @@ UUri {
 }
 ----
 
-Since this is a remote UUri, the MQTT Topic will simply be `Vehicle_1`.
+Since this is a remote UUri, the MQTT Topic will simply be `upr/Vehicle_1`.
 
 * The local UUri (without UAuthority):
 
@@ -112,7 +112,7 @@ UUri {
 }
 ----
 
-Since this is a local UUri, the MQTT Topic will be constructed from the UEnity name and the UResource name `body.access/door`.
+Since this is a local UUri, the MQTT Topic will be constructed from the UEnity name and the UResource name `upl/body.access/door`.
 
 === Payload Encoding
 


### PR DESCRIPTION
This is a draft of how a uTransport would communicate over MQTT:

I would envision that there is a device specific mqtt broker and a cloud based mqtt broker (or more). If a uMessage is being routed to the cloud only the uAuthority information is really needed in the topic. Once the uMessage reaches the correct uDevice, then the header is processed to get the uEntity and uResource from the sink uuri. The uMessage is then passed over the local mqtt broker to the correct component.

Things to discuss:
- Should microURI be used anywhere here?
- The uMessage payload is simply the uMessage protobuf object written to bytes. (vec<u8>)