### PR TITLE
Clarification of minimum viable UUri as being one that satisfies Micro Form

### DIFF
--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -105,7 +105,7 @@ The API signature:
 
 * All UMessage attributes metadata *MUST* be preserved during transmission and available to the receiver
 * *MUST* not manipulate the UMessage payload during transmission
-* *MUST* pass UUris which satisfy criteria for xref:../basics/uri.adoc#_micro_uris[Micro Uris]
+* *MUST* pass UUris for which `isMicroForm()` return true
 * *SHOULD* pass Resolved UUris (contains both names and numbers)
 * *SHOULD* use the Micro Uri serialization format
 

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -107,7 +107,6 @@ The API signature:
 * *MUST* not manipulate the UMessage payload during transmission
 * *MUST* pass UUris for which `isMicroForm()` return true
 * *SHOULD* pass Resolved UUris (contains both names and numbers)
-* *SHOULD* use the Micro Uri serialization format
 
 
 

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -105,8 +105,9 @@ The API signature:
 
 * All UMessage attributes metadata *MUST* be preserved during transmission and available to the receiver
 * *MUST* not manipulate the UMessage payload during transmission
-* *SHOULD* pass resolved UUris (contains both names and numbers)
-* *SHOULD* use the Miro Uri serialization format
+* *MUST* pass UUris which satisfy criteria for <<_micro_uris, Micro Uris>>
+* *SHOULD* pass Resolved UUris (contains both names and numbers)
+* *SHOULD* use the Micro Uri serialization format
 
 
 

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -105,7 +105,7 @@ The API signature:
 
 * All UMessage attributes metadata *MUST* be preserved during transmission and available to the receiver
 * *MUST* not manipulate the UMessage payload during transmission
-* *MUST* pass UUris which satisfy criteria for <<_micro_uris, Micro Uris>>
+* *MUST* pass UUris which satisfy criteria for link:../basics/uri.adoc[Micro Uris]
 * *SHOULD* pass Resolved UUris (contains both names and numbers)
 * *SHOULD* use the Micro Uri serialization format
 

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -105,7 +105,7 @@ The API signature:
 
 * All UMessage attributes metadata *MUST* be preserved during transmission and available to the receiver
 * *MUST* not manipulate the UMessage payload during transmission
-* *MUST* pass UUris which satisfy criteria for link:../basics/uri.adoc[Micro Uris]
+* *MUST* pass UUris which satisfy criteria for xref:../basics/uri.adoc#_micro_uris[Micro Uris]
 * *SHOULD* pass Resolved UUris (contains both names and numbers)
 * *SHOULD* use the Micro Uri serialization format
 


### PR DESCRIPTION
From #68, namely from [this clarification](https://github.com/eclipse-uprotocol/up-spec/issues/68#issuecomment-2007523728)

Updated to reflect that the minimum viable UUri that we should accept in UTransport::send() is that which satisfies the Micro Form.