### PR TITLE
Clarification of minimum viable UUri as being one that satisfies Micro Form for `UTransport::registerListener()` and `UTransport::unregisterListener`

### DIFF
--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -122,6 +122,8 @@ API Signature:
  * *MUST* support registering more than one listener per topic
  * *MUST* support registering more than one topic per listener
  * Transport implementations *MUST* declare the maximum number of listeners per topic that it can support. If the maximum number of listeners is reached, the transport *MUST* return `RESOURCE_EXHAUSTED` status code
+* *MUST* pass a UUri for which `isMicroForm()` returns true
+* *SHOULD* pass a Resolved UUri (contains both names and numbers)
 
 
 ==== Parameters
@@ -160,6 +162,9 @@ API Signature:
 | Listener to be unregistered
 
 |===
+
+* *MUST* pass a UUri for which `isMicroForm()` returns true
+* *SHOULD* pass a Resolved UUri (contains both names and numbers)
 
 
 === Receive()


### PR DESCRIPTION
Updating UTransport::registerListener() and UTransport::unregisterListener() to clarify that they take _at a minimum_ a UUri which satisfies isMicroForm() but SHOULD be passed Resolved UUris.

For issue #98 