### PR TITLE
Making Uri proto, microuri support mandatory and longuri support optional

### DIFF
--- a/up-core-api/uprotocol/uri.proto
+++ b/up-core-api/uprotocol/uri.proto
@@ -74,8 +74,8 @@ message UAuthority {
 // A uE that publishes events is a <b>Service</b> role.<br>
 // A uE that consumes events is an <b>Application</b> role.
 message UEntity {
-  optional string name = 1;    // Name of the entity
-  uint32 id = 2;      // The numeric ID for the uEntity assigned from the name/number registry
+  optional string name = 1;          // Name of the entity
+  uint32 id = 2;                     // The numeric ID for the uEntity assigned from the name/number registry
   optional uint32 version_major = 3; // optional major version of the uEntity
   optional uint32 version_minor = 4; // optional minor version of the uEntity
 }
@@ -91,10 +91,10 @@ message UEntity {
 // Resources are unique when prepended with UAuthority that represents the device and
 // UEntity that represents the service.
 message UResource {
-  string name = 1;      // Name of the resource
+  optional string name = 1;      // Name of the resource
   optional string instance = 2;  // Instance of the resource
   optional string message = 3;   // Message type for the resource
-  optional uint32 id = 4;        // Numerical representation of the UResource portion of the UUri
+  uint32 id = 4;                 // Numerical representation of the UResource portion of the UUri
 }
 
 

--- a/up-core-api/uprotocol/uri.proto
+++ b/up-core-api/uprotocol/uri.proto
@@ -74,8 +74,8 @@ message UAuthority {
 // A uE that publishes events is a <b>Service</b> role.<br>
 // A uE that consumes events is an <b>Application</b> role.
 message UEntity {
-  string name = 1;    // Name of the entity
-  optional uint32 id = 2;      // The numeric ID for the uEntity assigned from the name/number registry
+  optional string name = 1;    // Name of the entity
+  uint32 id = 2;      // The numeric ID for the uEntity assigned from the name/number registry
   optional uint32 version_major = 3; // optional major version of the uEntity
   optional uint32 version_minor = 4; // optional minor version of the uEntity
 }

--- a/up-core-api/uprotocol/uri.proto
+++ b/up-core-api/uprotocol/uri.proto
@@ -75,7 +75,7 @@ message UAuthority {
 // A uE that consumes events is an <b>Application</b> role.
 message UEntity {
   optional string name = 1;          // Name of the entity
-  uint32 id = 2;                     // The numeric ID for the uEntity assigned from the name/number registry
+  optional uint32 id = 2;            // The numeric ID for the uEntity assigned from the name/number registry
   optional uint32 version_major = 3; // optional major version of the uEntity
   optional uint32 version_minor = 4; // optional minor version of the uEntity
 }
@@ -94,7 +94,7 @@ message UResource {
   optional string name = 1;      // Name of the resource
   optional string instance = 2;  // Instance of the resource
   optional string message = 3;   // Message type for the resource
-  uint32 id = 4;                 // Numerical representation of the UResource portion of the UUri
+  optional uint32 id = 4;        // Numerical representation of the UResource portion of the UUri
 }
 
 


### PR DESCRIPTION
This PR implements issue #102 

It modifies uri.proto:

1. UEntity name is now optional
2. UResource name is now optional