### PR TITLE
Move UUri invariants to UAttributes specification

### DIFF
--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 
 UAttributes contain metadata describing a particular message's purpose, content and processing requirements.
 
-NOTE: Please refer to link:../up-core-api/uprotocol/uattributes.proto[uattributes.proto] for the latest version of the UAttributes data model.
+NOTE: Please refer to link:../up-core-api/uprotocol/v1/uattributes.proto[uattributes.proto] for the latest version of the UAttributes data model.
 
 uProtocol defines four types of messages:
 
@@ -218,7 +218,7 @@ The following table defines attributes that are used for RPC response messages i
 
 |`commstatus`
 |no
-|A link:../up-core-api/uprotocol/ustatus.proto[UCode] indicating an error that has occurred during the delivery of either the RPC request or response message. A value of `0` or no value indicates that no communication error has occurred.
+|A link:../up-core-api/uprotocol/v1/ustatus.proto[UCode] indicating an error that has occurred during the delivery of either the RPC request or response message. A value of `0` or no value indicates that no communication error has occurred.
 
 |===
 

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -102,6 +102,7 @@ The following table defines attributes that are used for publish messages in add
 |yes
 |A link:uri.adoc[UUri] representing the topic that this message is published to.
 
+* The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFF[`.
 |===
 
 [#notification-attributes]
@@ -121,9 +122,13 @@ The following table defines attributes that are used for notification messages i
 |yes
 |A link:uri.adoc[UUri] representing the component that this notification originates from.
 
+* The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFF[`.
+
 |`sink`
 |yes
 |A link:uri.adoc[UUri] representing the receiver of this notification.
+
+* The UUri's `resource_id` *MUST* be set to `0`.
 
 |===
 
@@ -144,9 +149,13 @@ The following table defines attributes that are used for RPC request messages in
 |yes
 |The link:uri.adoc[UUri] that the service consumer expects to receive the response message at.
 
+* The UUri's `resource_id` *MUST* be set to `0`.
+
 |`sink`
 |yes
 |A link:uri.adoc[UUri] identifying the service provider's method to invoke.
+
+* The UUri's `resource_id` *MUST* be set to a value in range `]0, 0x8000[`.
 
 |`priority`
 |yes
@@ -187,9 +196,13 @@ The following table defines attributes that are used for RPC response messages i
 |yes
 |The link:uri.adoc[UUri] identifying the method that has been invoked and which this message is the outcome of.
 
+* The UUri's `resource_id` *MUST* be set to a value in range `]0, 0x8000[`.
+
 |`sink`
 |yes
 |The link:uri.adoc[UUri] that the service consumer expects to receive this response message at.
+
+* The UUri's `resource_id` *MUST* be set to `0`.
 
 |`reqid`
 |yes
@@ -208,3 +221,8 @@ The following table defines attributes that are used for RPC response messages i
 |A link:../up-core-api/uprotocol/ustatus.proto[UCode] indicating an error that has occurred during the delivery of either the RPC request or response message. A value of `0` or no value indicates that no communication error has occurred.
 
 |===
+
+
+== Validation
+
+Each link:../languages.adoc[uProtocol Language Library] *MUST* provide means to assert the consistency of a message's attributes according to its type as defined in the sections above. The concrete implementation should follow common practices of the particular programming language.

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -102,7 +102,7 @@ The following table defines attributes that are used for publish messages in add
 |yes
 |A link:uri.adoc[UUri] representing the topic that this message is published to.
 
-* The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFF[`.
+* The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFF)`.
 |===
 
 [#notification-attributes]
@@ -122,7 +122,7 @@ The following table defines attributes that are used for notification messages i
 |yes
 |A link:uri.adoc[UUri] representing the component that this notification originates from.
 
-* The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFF[`.
+* The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFF)`.
 
 |`sink`
 |yes
@@ -155,7 +155,7 @@ The following table defines attributes that are used for RPC request messages in
 |yes
 |A link:uri.adoc[UUri] identifying the service provider's method to invoke.
 
-* The UUri's `resource_id` *MUST* be set to a value in range `]0, 0x8000[`.
+* The UUri's `resource_id` *MUST* be set to a value in range `(0, 0x8000)`.
 
 |`priority`
 |yes
@@ -196,7 +196,7 @@ The following table defines attributes that are used for RPC response messages i
 |yes
 |The link:uri.adoc[UUri] identifying the method that has been invoked and which this message is the outcome of.
 
-* The UUri's `resource_id` *MUST* be set to a value in range `]0, 0x8000[`.
+* The UUri's `resource_id` *MUST* be set to a value in range `(0, 0x8000)`.
 
 |`sink`
 |yes

--- a/basics/uri.adoc
+++ b/basics/uri.adoc
@@ -99,9 +99,10 @@ uEntities *MAY* assume both the Service and Application roles.
 
 [.specitem,oft-sid="dsn~entity-id~1"]
 --
-A UUri's `ue_id` property value determines the type and instance of the service being referred to. +
-The value's _least_ significant 16 bits contain the _service ID_, representing the service interface type.
-The value's _most_ significant 16 bits contain the _service instance ID_. +
+A UUri's `ue_id` property value determines the type and instance of the service being referred to:
+
+* The value's _least_ significant 16 bits contain the _service ID_, representing the service interface type.
+* The value's _most_ significant 16 bits contain the _service instance ID_.
 --
 
 === Resource
@@ -113,26 +114,6 @@ Resources and methods are uniquely identified within a service interface by mean
 [.specitem,oft-sid="dsn~resource-id~1"]
 --
 A UUri's `resource_id` contains the identifier of the resource or method being referred to.
---
-
-[.specitem,oft-sid="dsn~resource-rpc-method~1"]
---
-A UUri refers to an RPC service method if its `isRpcMethod` predicate as defined below evaluates to `true`.
-
-[source,ocl]
-----
-def: isRpcMethod() : Boolean = resource_id > 0 and resource_id < 0x8000
-----
---
-
-[.specitem,oft-sid="dsn~resource-rpc-response~1"]
---
-A UUri refers to an RPC response address if its `isRpcResponse` predicate as defined below evaluates to `true`.
-
-[source,ocl]
-----
-def: isRpcResponse() : Boolean = resource_id = 0
-----
 --
 
 [#uri-definition]
@@ -175,7 +156,7 @@ A URI's _path_ *MUST* be mapped to/from the UUri's `ue_id`, `ue_version_major` a
 Each property value *MUST* be mapped to a _segment_ following the rules defined in link:https://datatracker.ietf.org/doc/html/rfc3986#section-3.3[RFC3986, Section 3.3].
 
 The `ue_id`, `ue_version_major` and `resource_id` *MUST* be mapped to the _upper-case_ link:https://www.rfc-editor.org/rfc/rfc4648#section-8[base16 encoding]
-of the corresponding property values.
+of the corresponding property values. Leading zeros (`0`) *MAY* be omitted.
 --
 
 === Examples
@@ -285,100 +266,6 @@ impl UUri {
 }
 ----
 
-
-
-== Validation
-
-[.specitem,oft-sid="req~validation~1",oft-needs="impl,utest"]
---
-Each link:../languages.adoc[uProtocol Language Library] *MUST* provide means to perform the checks defined by means of predicates on the UUri data model. The concrete implementation should follow common practices of the particular programming language.
---
-
-For example, a Java library might implement a `UriValidator` class providing corresponding _static_ methods.
-
-[source,java]
-----
-public final class UriValidator {
-  /**
-   * @returns {@code true} if the URI represents an RPC method.
-   */
-  public static boolean isRpcMethod(UUri: uri) {
-    ...
-  }
-  /**
-   * @throws UuriValidationException if the URI does not represent an RPC method.
-   *                     The exception may contain details regarding the violated
-   *                     constraint(s).
-   */
-  public static void validateRpcMethod(UUri: uri) throws UuriValidationException {
-    if (!UriValidator.isRpcMethod(uri)) {
-      throw new UuriValidationException("not an RPC Method URI");
-    }
-  }
-}
-----
-
-Alternatively, the `UUri` class might provide corresponding methods.
-
-[source,java]
-----
-public class UUri {
-  /**
-   * @returns {@code true} if this URI represents an RPC method.
-   */
-  public final boolean isRpcMethod() {
-    ...
-  }
-  /**
-   * @throws UuriValidationException if this URI does not represent an RPC method.
-   *                     The exception may contain details regarding the violated
-   *                     constraint(s).
-   */
-  public final void validateRpcMethod() throws UuriValidationException {
-    if (!this.isRpcMethod()) {
-      throw new UuriValidationException("not an RPC Method URI");
-    }
-  }
-}
-----
-
-Similarly, a Rust library might implement a `UriValidator` struct providing corresponding functions
-
-[source,rust]
-----
-pub struct UriValidator {}
-
-impl UriValidator {
-  pub fn is_rpc_method(uri: &UUri) -> bool {
-    ...
-  }
-  pub fn validate_rpc_method(uri: &UUri) -> Result<(), UuriValidationError> {
-    if is_rpc_method(uri) {
-      Ok(())
-    } else {
-      Err(UuriValidationError::new("not an RPC Method URI"))
-    }
-  }
-}
-----
-
-or implement the functions on the `UUri` struct
-
-[source,rust]
-----
-impl UUri {
-  pub fn is_rpc_method(&self) -> bool {
-    ...
-  }
-  pub fn validate_rpc_method(&self) -> Result<(), UuriValidationError> {
-    if self.is_rpc_method() {
-      Ok(())
-    } else {
-      Err(UuriValidationError::new("not an RPC Method URI"))
-    }
-  }
-}
-----
 
 == Pattern Matching
 


### PR DESCRIPTION
The invariants for UUri's used in a certain context have been moved
from the UUri to the UAttributes specification where they are now
defined in the proper (message type) context.