### PR TITLE
Align uri.proto with spec

### DIFF
--- a/up-core-api/uprotocol/v1/uri.proto
+++ b/up-core-api/uprotocol/v1/uri.proto
@@ -20,49 +20,28 @@ option java_outer_classname = "UUriProto";
 option java_multiple_files = true;
 
 
-// uProtocol URI <b>URI</b>.
 // Data model definition for source and destination addressing of messages sent to/from
 // devices, services, methods, topics, etc... 
 message UUri {
   // Authority Name.
   //
   // Could be the host name, ip address, device & domain names, etc..
-  // empty: No authority meaning a local address per RFC 3986
-  // "*": Wildcard character to represent all authorities
   string authority_name = 1;
 
-  // Software Entity (uE) Identifiers.
-  //
-  // Service ID (lower 16 bits):
-  // 0x0000: Reserved for uSubscription
-  // 0x0001-0xFFFE: Software Entity id
-  // 0xFFFF: Wildcard to represent all uE
-  // 
-  // Instance ID (upper 16 bits):
-  // 0x0000: Don't care, assume instance id of 0
-  // 0x0001-0xFFFE: Instance id
-  // 0xFFFF: Wildcard to represent all instances
+  // Software Entity (uEntity) Identifiers.
   uint32 ue_id = 2;
 
-  // Software Entity (uE) major version number.
-  //
-  // 0x0: reserved
-  // 0x1-0xFE: Major version number 1-254
-  // 0xFF: Wildcard to represent all versions
+  // Software Entity (uEntity) major version number.
   uint32 ue_version_major = 3;
 
-  // uE resource id.
+  // uEntity resource id.
   //
   // Identifier used to represent either a method, publish topic, or notification topic.  
-  // 0x0: Default Resource id (for response messages)
-  // 0x0001-0x7FFF: Methods
-  // 0x8000-0xFFFE: Publish or notifications topics
-  // 0xFFFF: Wildcard to represent all resources
   uint32 resource_id = 4;
 }
 
 
-// Repeated list of URIs that can be used for batching APIs
+// List of URIs that can be used for batching APIs.
 message UUriBatch {
-  repeated UUri uris = 1; // Repeated list of URIs
+  repeated UUri uris = 1;
 }


### PR DESCRIPTION
The UUri specification contains all relevant definitions and
requirements for a URI's components. The proto3 file simply defines
the encoding to use when sending UUris over the wire.

All comments containing field definitions/requirements have been
removed in order to prevent diverging semantics.