### PR TITLE
removed zero-length segments from mqtt 5 spec

### DIFF
--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -129,9 +129,9 @@ The MQTT topic a message is published on utilizes the source and sink UUri field
 
 `{client_identifier}/{source.authority_name}/{source.ue_id}/{source.ue_version_major}/{source.resource_id}/{sink.authority_name}/{sink.ue_id}/{sink.ue_version_major}/{sink.resource_id}`
 
-If the no sink uuri is provided, then the topic sections using sink uuri segments are empty, like so:
+If the no sink uuri is provided, then the topic sections using sink uuri segments are removed, like so:
 
-`{client_identifier}/{source.authority_name}/{source.ue_id}/{source.ue_version_major}/{source.resource_id}////`
+`{client_identifier}/{source.authority_name}/{source.ue_id}/{source.ue_version_major}/{source.resource_id}`
 
 The client_identifier is used to determine where messages are coming from. The valid values for the client_identifier are:
 
@@ -154,7 +154,7 @@ How a source and sink UUri are mapped to an MQTT topic when the message is sent 
 | source | sink | topic
 
 | //vehicle_1.veh.com/AB34/1/12CD | //vehicle_2.veh.com/43BA/1/DC21 | {cli_identifier}/vehicle_1.veh.com/AB34/1/12CD/vehicle_2.veh.com/43BA/1/DC21
-| //vehicle_1.veh.com/AB34/1/12CD | None | {cli_identifier}/vehicle_1.veh.com/AB34/1/12CD////
+| //vehicle_1.veh.com/AB34/1/12CD | None | {cli_identifier}/vehicle_1.veh.com/AB34/1/12CD
 |===
 
 Listener examples for a device:
@@ -163,11 +163,11 @@ Listener examples for a device:
 |===
 | goal | source filter | sink filter | listener topic
 
-| Subscribe to a specific Publish topic | //vehicle_1.veh.com/AB34/1/12CD | None | d/vehicle_1.veh.com/AB34/1/12CD////
+| Subscribe to a specific Publish topic | //vehicle_1.veh.com/AB34/1/12CD | None | d/vehicle_1.veh.com/AB34/1/12CD
 | Subscribe to all incoming requests to a specific method | empty | //vehicle_1.veh.com/AB34/1/12CD | d/\+/+/\+/+/vehicle_1.veh.com/AB34/1/12CD
 | Subscribe to a specific Notification topic | //vehicle_2.veh.com/43BA/1/DC21 | //vehicle_1.veh.com/AB34/1/0 | d/vehicle_2.veh.com/43BA/1/DC21/vehicle_1.veh.com/AB34/1/0
 | Subscribe to all incoming messages to a UAuthority from the cloud | empty | //vehicle_1.veh.com/FFFF/FF/FFFF | c/\+/+/\+/+/vehicle_1.veh.com/\+/+/+
-| Subscribe to all publish messages from a different UAuthority | //vehicle_1.veh.com/FFFF/FF/FFFF | None | d/vehicle_1.veh.com/\+/+/+////
+| Subscribe to all publish messages from a different UAuthority | //vehicle_1.veh.com/FFFF/FF/FFFF | None | d/vehicle_1.veh.com/\+/+/+
 | Streamer subscribing to receive any sent notifications, requests, or responses to its device from the cloud | empty | //vehicle_1.veh.com/FFFF/FF/0 | c/\+/+/\+/+/vehicle_1.veh.com/\+/+/0
 |===
 
@@ -179,8 +179,8 @@ Shows how source and sink filters can be used to construct wildcard topics for l
 |===
 | goal | source filter | sink filter | listener topic
 
-| Subscribe to all publish messages from devices | empty | None | d/\+/+/\+/+////
-| Subscribe to all messages sent from a UAuthority | //vehicle_1.veh.com/FFFF/FF/FFFF | empty | d/vehicle_1.veh.com/\+/+/\+/+/\+/+/\+/+
+| Subscribe to all publish messages from devices | empty | None | d/\+/+/\+/+
+| Subscribe to all message types but publish messages sent from a UAuthority | //vehicle_1.veh.com/FFFF/FF/FFFF | empty | d/vehicle_1.veh.com/\+/+/\+/+/\+/+/\+/+
 |===
 
 === Payload Encoding


### PR DESCRIPTION
Certain messaging brokers handle zero-length segments differently for topics, as such we will simply remove the zero length segments if the sink uri is 'None'