### PR TITLE
Separate UCode from UStatus

### DIFF
--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -18,6 +18,7 @@ package uprotocol.v1;
 import "uprotocol/v1/uri.proto";
 import "uprotocol/v1/uuid.proto";
 import "uprotocol/v1/ustatus.proto";
+import "uprotocol/v1/ucode.proto";
 import "uprotocol/uoptions.proto";
 
 option java_package = "org.eclipse.uprotocol.v1";

--- a/up-core-api/uprotocol/v1/ucode.proto
+++ b/up-core-api/uprotocol/v1/ucode.proto
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under
+ * the terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+syntax = "proto3";
+
+package uprotocol.v1;
+
+option java_package = "org.eclipse.uprotocol.v1";
+option java_outer_classname = "UCodeProto";
+option java_multiple_files = true;
+
+// Canonical Error codes for uProtocol APIs
+enum UCode {
+  // Completes successfully
+  OK = 0;
+
+  // Operation has been cancelled by the caller
+  CANCELLED = 1;
+
+  // An unknown (but not critical) error has occurred
+  UNKNOWN = 2;
+
+  // Passed arguments are invalid (ex. improperly formatted)
+  INVALID_ARGUMENT = 3;
+
+  // Operation has expired (timeout)
+  DEADLINE_EXCEEDED = 4;
+
+  // Operation cannot be completed because the requested entity was not
+  // found (ex. database lookup and the data is not found)
+  // Calling uE *MAY* retry the operation with back-off
+  NOT_FOUND = 5;
+
+  // The calling uE requested to add/create something that already exists
+  // (ex. add to a database something that is already there)
+  ALREADY_EXISTS = 6;
+
+  // The calling uE is authenticated but not permitted to call the API
+  PERMISSION_DENIED = 7;
+
+  // The calling uE does not have valid authentication credentials for the API
+  UNAUTHENTICATED = 16;
+
+  // The resource being accessed has been exhausted (ex. out of disk space, etc...)
+  RESOURCE_EXHAUSTED = 8;
+
+  // The system (service) is in a state that it cannot handle the request
+  // Calling uEs *SHOULD NOT* retry till the system state has been corrected
+  FAILED_PRECONDITION = 9;
+
+  // The operation was aborted, typically due to a concurrency issue such as
+  // a sequencer check failure or transaction abort
+  // Calling uEs *MAY* retry but at a higher frequency than UNAVAILABLE
+  ABORTED = 10;
+
+  // A caller would typically iterating through the results from said API
+  // and can is expected to detect the end of the results (out of range)
+  OUT_OF_RANGE = 11;
+
+  // Part or all of the requested operation has not been implemented yet
+  UNIMPLEMENTED = 12;
+
+  // A serious internal error has not described by a known error code
+  INTERNAL = 13;
+
+  // The operation is currently unavailable
+  // Calling uEs *MAY* retry with back-off
+  UNAVAILABLE = 14;
+
+  // When an unrecoverable data loss or corruption has occurred
+  DATA_LOSS = 15;
+}

--- a/up-core-api/uprotocol/v1/ustatus.proto
+++ b/up-core-api/uprotocol/v1/ustatus.proto
@@ -16,6 +16,8 @@ syntax = "proto3";
 package uprotocol.v1;
 
 import "google/protobuf/any.proto";
+import "uprotocol/v1/ucode.proto";
+
 option java_package = "org.eclipse.uprotocol.v1";
 option java_outer_classname = "UStatusProto";
 option java_multiple_files = true;
@@ -24,7 +26,7 @@ option java_multiple_files = true;
 // google.rpc.Status
 message UStatus {
   // The status code.
-  UCode code = 1;
+  uprotocol.v1.UCode code = 1;
 
   // A developer-facing error message, which should be in English. Any
   // user-facing error message should be localized and sent in the
@@ -34,67 +36,4 @@ message UStatus {
   // A list of messages that carry the error details.  There is a common set of
   // message types for APIs to use.
   repeated google.protobuf.Any details = 3;
-}
-
-
-// Canonical Error codes for uProtocol APIs
-enum UCode {
-  // Completes successfully
-  OK = 0;
-
-  // Operation has been cancelled by the caller
-  CANCELLED = 1;
-
-  // An unknown (but not critical) error has occurred
-  UNKNOWN = 2;
-
-  // Passed arguments are invalid (ex. improperly formatted)
-  INVALID_ARGUMENT = 3;
-
-  // Operation has expired (timeout)
-  DEADLINE_EXCEEDED = 4;
-
-  // Operation cannot be completed because the requested entity was not
-  // found (ex. database lookup and the data is not found)
-  // Calling uE *MAY* retry the operation with back-off
-  NOT_FOUND = 5;
-
-  // The calling uE requested to add/create something that already exists
-  // (ex. add to a database something that is already there)
-  ALREADY_EXISTS = 6;
-
-  // The calling uE is authenticated but not permitted to call the API
-  PERMISSION_DENIED = 7;
-
-  // The calling uE does not have valid authentication credentials for the API
-  UNAUTHENTICATED = 16;
-
-  // The resource being accessed has been exhausted (ex. out of disk space, etc...)
-  RESOURCE_EXHAUSTED = 8;
-
-  // The system (service) is in a state that it cannot handle the request
-  // Calling uEs *SHOULD NOT* retry till the system state has been corrected
-  FAILED_PRECONDITION = 9;
-
-  // The operation was aborted, typically due to a concurrency issue such as
-  // a sequencer check failure or transaction abort
-  // Calling uEs *MAY* retry but at a higher frequency than UNAVAILABLE
-  ABORTED = 10;
-
-  // A caller would typically iterating through the results from said API
-  // and can is expected to detect the end of the results (out of range)
-  OUT_OF_RANGE = 11;
-
-  // Part or all of the requested operation has not been implemented yet
-  UNIMPLEMENTED = 12;
-
-  // A serious internal error has not described by a known error code
-  INTERNAL = 13;
-
-  // The operation is currently unavailable
-  // Calling uEs *MAY* retry with back-off
-  UNAVAILABLE = 14;
-
-  // When an unrecoverable data loss or corruption has occurred
-  DATA_LOSS = 15;
 }


### PR DESCRIPTION
Mechatronics world would like to use UCode that that we have consistent definitions of errors codes across all uServices however they cannot and will not use UStatus that also includes string messages and repeated any (that is more used for high-compute services. Although they can still achieve their goal by only using UCode from uservice.proto, splitting them means we can add the SOME/Ip serialization metadata (CustomOptions) to the ucode.proto and we do not have do do that for ustatus.proto.

#173