### PR TITLE
Fix warning for unused ustatus.proto

### DIFF
--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -17,7 +17,6 @@ package uprotocol.v1;
 
 import "uprotocol/v1/uri.proto";
 import "uprotocol/v1/uuid.proto";
-import "uprotocol/v1/ustatus.proto";
 import "uprotocol/v1/ucode.proto";
 import "uprotocol/uoptions.proto";
 


### PR DESCRIPTION
Once I committed #173 I caused an issue with a warning that appears that ustatus proto is included in uattributes.proto even though it is not used so this issue will be used to remove the warning.

#185