### PR TITLE
Add idempotent requirement to UTransport APIs.

### DIFF
--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -237,6 +237,7 @@ UTransport implementations
 * *MUST* support registering more than one listener for any given address patterns
 * *MUST* support registering the same listener for multiple address patterns
 * *MUST* document the maximum supported number of listeners per address pattern.
+* *MUST* be idempotent, multiple calls to said API with the same parameters *MUST* have the same effect as a single call.
 
 .Registering a Listener
 [mermaid]
@@ -294,6 +295,7 @@ UTransport implementations
 
 * *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method>>. In that case, the <<register-listener>> method *MUST* also fail accordingly.
 * *MUST* fail with a `UCode.NOT_FOUND`, if no such listener had been registered before
+* *MUST* be idempotent, multiple calls to said API with the same parameters *MUST* have the same effect as a single call.
 
 .Unregistering a Listener
 [mermaid]

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -295,7 +295,6 @@ UTransport implementations
 
 * *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method>>. In that case, the <<register-listener>> method *MUST* also fail accordingly.
 * *MUST* fail with a `UCode.NOT_FOUND`, if no such listener had been registered before
-* *MUST* be idempotent, multiple calls to said API with the same parameters *MUST* have the same effect as a single call.
 
 .Unregistering a Listener
 [mermaid]


### PR DESCRIPTION
Calling the UTransport register and unregister API multiple times with the same parameters return the same value as if you called it the first time in lieu of returning  `UCode.ALREADY_EXISTS`.

#193