### PR TITLE
Updates to uattributes and MQTT5 specifications

### DIFF
--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -60,7 +60,7 @@ The following table defines attributes that are used for all message types:
 |link:uuid.adoc[UUID]
 |yes
 a|
-[.specitem,oft-sid="req~up-attributes-id~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-id~1",oft-needs="impl,utest"]
 --
 Every message *MUST* have a unique message identifier. The timestamp contained in the UUID is used as the message's creation time.
 --
@@ -70,7 +70,7 @@ Every message *MUST* have a unique message identifier. The timestamp contained i
 |no
 a|
 The QoS level that this message should be processed/delivered with. 
-[.specitem,oft-sid="req~up-attributes-priority~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-priority~1",oft-needs="impl,utest"]
 --
 A consumer *MUST* assume a message to have the link:qos.adoc#default-priority[default priority] if not set explicitly.
 --
@@ -80,11 +80,11 @@ A consumer *MUST* assume a message to have the link:qos.adoc#default-priority[de
 |no
 a|
 The amount of time (in milliseconds) after which this message is no longer delivered/processed.
-[.specitem,oft-sid="req~up-attributes-ttl-timeout~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-ttl-timeout~1",oft-needs="impl,utest"]
 --
 A consumer *MUST NOT* process an expired message. A message is expired if the TTL is > `0` and the consumer's current time is _after_ the message's creation time _plus_ its TTL.
 --
-[.specitem,oft-sid="req~up-attributes-ttl~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-ttl~1",oft-needs="impl,utest"]
 --
 A consumer *MUST* not consider a message expired if it has a TTL value of `0`.
 --
@@ -98,7 +98,7 @@ stem:[t_{current} > t_{id} + ttl]
 a|
 A tracing identifier to use for correlating messages across the system. Intended to be compatible with https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md[CloudEvents distributed tracing extension].
 
-[.specitem,oft-sid="req~up-attributes-traceparent~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-traceparent~1",oft-needs="impl,utest"]
 --
 * *MAY* contain traceparent attribute.
 --
@@ -108,7 +108,7 @@ A tracing identifier to use for correlating messages across the system. Intended
 |link:upayloadformat.adoc[UPayloadFormat]
 |no
 a|The format of the payload (data).
-[.specitem,oft-sid="req~up-attributes-payload-format~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-payload-format~1",oft-needs="impl,utest"]
 --
 * *MAY* contain payload format attribute.
 --
@@ -127,7 +127,7 @@ The following table defines attributes that are used for publish messages in add
 |`type`
 |yes
 a| 
-[.specitem,oft-sid="req~up-attributes-publish-type~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-publish-type~1",oft-needs="impl,utest"]
 --
 *MUST* be set to `UMESSAGE_TYPE_PUBLISH`.
 --
@@ -136,7 +136,7 @@ a|
 |yes
 a|A link:uri.adoc[UUri] representing the topic that this message is published to.
 
-[.specitem,oft-sid="req~up-attributes-publish-source~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-publish-source~1",oft-needs="impl,utest"]
 --
 * The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFE]`.
 --
@@ -146,7 +146,7 @@ a|A link:uri.adoc[UUri] representing the topic that this message is published to
 a|A link:uri.adoc[UUri] representing the receiver of this published message. This information is 
 only required when we are sending the published event between devices through the streamer, publishers are not required to populate this information.
 
-[.specitem,oft-sid="req~up-attributes-publish-sink~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-publish-sink~1",oft-needs="impl,utest"]
 --
 * *MAY* be present in the message. If present, the UUri *MUST* only contain the `authority_name` field.
 --
@@ -165,7 +165,7 @@ The following table defines attributes that are used for notification messages i
 |`type`
 |yes
 a|
-[.specitem,oft-sid="req~up-attributes-notification-type~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-notification-type~1",oft-needs="impl,utest"]
 --
 *MUST* be set to `UMESSAGE_TYPE_NOTIFICATION`.
 --
@@ -174,7 +174,7 @@ a|
 a|
 A link:uri.adoc[UUri] representing the component that this notification originates from.
 
-[.specitem,oft-sid="req~up-attributes-notification-source~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-notification-source~1",oft-needs="impl,utest"]
 --
 * The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFE]`.
 --
@@ -183,7 +183,7 @@ A link:uri.adoc[UUri] representing the component that this notification originat
 |yes
 a|A link:uri.adoc[UUri] representing the receiver of this notification.
 
-[.specitem,oft-sid="req~up-attributes-notification-sink~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-notification-sink~1",oft-needs="impl,utest"]
 --
 * The UUri's `resource_id` *MUST* be set to `0`.
 --
@@ -202,7 +202,7 @@ The following table defines attributes that are used for RPC request messages in
 |`type`
 |yes
 a|
-[.specitem,oft-sid="req~up-attributes-request-type~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-request-type~1",oft-needs="impl,utest"]
 --
 *MUST* be set to `UMESSAGE_TYPE_REQUEST`.
 --
@@ -211,7 +211,7 @@ a|
 |yes
 a|The link:uri.adoc[UUri] that the service consumer expects to receive the response message at.
 
-[.specitem,oft-sid="req~up-attributes-request-source~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-request-source~1",oft-needs="impl,utest"]
 --
 * The UUri's `resource_id` *MUST* be set to `0`.
 --
@@ -220,7 +220,7 @@ a|The link:uri.adoc[UUri] that the service consumer expects to receive the respo
 |yes
 a|A link:uri.adoc[UUri] identifying the service provider's method to invoke.
 
-[.specitem,oft-sid="req~up-attributes-request-sink~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-request-sink~1",oft-needs="impl,utest"]
 --
 * The UUri's `resource_id` *MUST* be set to a value in range `[1, 0x7FFF]`.
 --
@@ -229,16 +229,17 @@ a|A link:uri.adoc[UUri] identifying the service provider's method to invoke.
 |yes
 a|The link:qos.adoc[QoS] level that this message should be processed/delivered with.
 
-[.specitem,oft-sid="req~up-attributes-request-priority~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-request-priority~1",oft-needs="impl,utest"]
 --
 * *MUST* be set to `UPRIORITY_CS4` or higher.
 --
+
 
 |`ttl`
 |yes
 a|The amount of time (in milliseconds) after which this request message should no longer be delivered to or processed by a service provider.
 
-[.specitem,oft-sid="req~up-attributes-request-ttl~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-request-ttl~1",oft-needs="impl,utest"]
 --
 * *MUST* be set to a value > 0
 --
@@ -247,7 +248,7 @@ a|The amount of time (in milliseconds) after which this request message should n
 |no
 a|The service consumer's permission level as defined in link:permissions.adoc#_code_based_access_permissions_caps[Code-Based uE Access Permissions (CAPs)].
 
-[.specitem,oft-sid="req~up-attributes-permission-level~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-permission-level~1",oft-needs="impl,utest"]
 --
 * *MAY* contain permission level attribute.
 --
@@ -256,7 +257,7 @@ a|The service consumer's permission level as defined in link:permissions.adoc#_c
 |no
 a|The service consumer's access token as defined in link:permissions.adoc#_token_based_access_permissionstaps[Token-Based uE Access Permissions (TAPs)].
 
-[.specitem,oft-sid="req~up-attributes-request-token~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-request-token~1",oft-needs="impl,utest"]
 --
 * *MAY* contain token attribute.
 --
@@ -275,7 +276,7 @@ The following table defines attributes that are used for RPC response messages i
 |`type`
 |yes
 a|
-[.specitem,oft-sid="req~up-attributes-response-type~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-response-type~1",oft-needs="impl,utest"]
 --
 *MUST* be set to `UMESSAGE_TYPE_RESPONSE`.
 --
@@ -284,7 +285,7 @@ a|
 |yes
 a|The link:uri.adoc[UUri] identifying the method that has been invoked and which this message is the outcome of.
 
-[.specitem,oft-sid="req~up-attributes-response-source~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-response-source~1",oft-needs="impl,utest"]
 --
 * The UUri's `resource_id` *MUST* be set to a value in range `[1, 0x7FFF]`.
 --
@@ -293,7 +294,7 @@ a|The link:uri.adoc[UUri] identifying the method that has been invoked and which
 |yes
 a|The link:uri.adoc[UUri] that the service consumer expects to receive this response message at.
 
-[.specitem,oft-sid="req~up-attributes-response-sink~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-response-sink~1",oft-needs="impl,utest"]
 --
 * The UUri's `resource_id` *MUST* be set to `0`.
 --
@@ -307,7 +308,7 @@ a|The link:uri.adoc[UUri] that the service consumer expects to receive this resp
 a|
 The link:qos.adoc[QoS] level that this message should be processed/delivered with. 
 
-[.specitem,oft-sid="req~up-attributes-response-reqid~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-response-reqid~1",oft-needs="impl,utest"]
 --
 * *MUST* be the same value as that of the corresponding request message's `priority` attribute.
 --
@@ -317,7 +318,7 @@ The link:qos.adoc[QoS] level that this message should be processed/delivered wit
 a|
 The amount of time after which this response message should no longer be delivered to or processed by the service consumer.
 
-[.specitem,oft-sid="req~up-attributes-response-ttl~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-response-ttl~1",oft-needs="impl,utest"]
 --
 * *MUST* be the same value as that of the corresponding request message's `ttl` attribute.
 --
@@ -326,7 +327,7 @@ The amount of time after which this response message should no longer be deliver
 |no
 a|A link:../up-core-api/uprotocol/v1/ustatus.proto[UCode] indicating an error that has occurred during the delivery of either the RPC request or response message. A value of `0` or no value indicates that no communication error has occurred.
 
-[.specitem,oft-sid="req~up-attributes-response-commstatus~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~up-attributes-response-commstatus~1",oft-needs="impl,utest"]
 --
 * *MUST* contain commstatus attribute if the request message was not delivered successfully or the server was unable to process the request.
 --

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -69,11 +69,12 @@ Every message *MUST* have a unique message identifier. The timestamp contained i
 |link:qos.adoc[UPriority]
 |no
 a|
-The QoS level that this message should be processed/delivered with. If not specified explicitly, the link:qos.adoc#default-priority[default priority level] is assumed.
+The QoS level that this message should be processed/delivered with. 
 [.specitem,oft-sid="req~up-attributes-priority~1",oft-needs="impl,utest"]
 --
-* *MUST* have a priority attribute.
+A consumer *MUST* assume a message to have the link:qos.adoc#default-priority[default priority] if not set explicitly.
 --
+
 |`ttl`
 |`unsigned integer`
 |no

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -142,9 +142,9 @@ a|A link:uri.adoc[UUri] representing the topic that this message is published to
 --
 
 |`sink`
-|no
+|no (see Description)
 a|A link:uri.adoc[UUri] representing the receiver of this published message. This information is 
-only required when we are sending the published event between devices through the streamer, publishers are not required to populate this information.
+only required when we are sending the published event between devices through a streamer. A uEntity sending a Publish message is not required to populate this information.
 
 [.specitem,oft-sid="dsn~up-attributes-publish-sink~1",oft-needs="impl,utest"]
 --

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -79,14 +79,15 @@ The QoS level that this message should be processed/delivered with. If not speci
 |no
 a|
 The amount of time (in milliseconds) after which this message is no longer delivered/processed.
-[.specitem,oft-sid="req~up-attributes-ttl~1",oft-needs="impl,utest"]
---
-* *MUST* have a TTL attribute.
---
 [.specitem,oft-sid="req~up-attributes-ttl-timeout~1",oft-needs="impl,utest"]
 --
-* The message *MUST* expire if the current time is greater than the sum of the message's creation time and the TTL value.
+A consumer *MUST NOT* process an expired message. A message is expired if the TTL is > `0` and the consumer's current time is _after_ the message's creation time _plus_ its TTL.
 --
+[.specitem,oft-sid="req~up-attributes-ttl~1",oft-needs="impl,utest"]
+--
+A consumer *MUST* not consider a message expired if it has a TTL value of `0`.
+--
+
 
 stem:[t_{current} > t_{id} + ttl]
 

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -59,29 +59,57 @@ The following table defines attributes that are used for all message types:
 |`id`
 |link:uuid.adoc[UUID]
 |yes
-|A unique message identifier. The timestamp contained in the UUID is used as the message's creation time.
+a|
+[.specitem,oft-sid="req~up-attributes-id~1",oft-needs="impl,utest"]
+--
+Every message *MUST* have a unique message identifier. The timestamp contained in the UUID is used as the message's creation time.
+--
 
 |`priority`
 |link:qos.adoc[UPriority]
 |no
-|The QoS level that this message should be processed/delivered with. If not specified explicitly, the link:qos.adoc#default-priority[default priority level] is assumed.
-
+a|
+The QoS level that this message should be processed/delivered with. If not specified explicitly, the link:qos.adoc#default-priority[default priority level] is assumed.
+[.specitem,oft-sid="req~up-attributes-priority~1",oft-needs="impl,utest"]
+--
+* *MUST* have a priority attribute.
+--
 |`ttl`
 |`unsigned integer`
 |no
-a|The amount of time (in milliseconds) after which this message *MUST* no longer be delivered/processed. The message is considered expired if this attribute is set to a positive value and
+a|
+The amount of time (in milliseconds) after which this message is no longer delivered/processed.
+[.specitem,oft-sid="req~up-attributes-ttl~1",oft-needs="impl,utest"]
+--
+* *MUST* have a TTL attribute.
+--
+[.specitem,oft-sid="req~up-attributes-ttl-timeout~1",oft-needs="impl,utest"]
+--
+* The message *MUST* expire if the current time is greater than the sum of the message's creation time and the TTL value.
+--
 
 stem:[t_{current} > t_{id} + ttl]
 
 |`traceparent`
 |https://w3c.github.io/trace-context/#traceparent-header[W3C Trace Context Level 3, traceparent]
 |no
-|A tracing identifier to use for correlating messages across the system. Intended to be compatible with https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md[CloudEvents distributed tracing extension].
+a|
+A tracing identifier to use for correlating messages across the system. Intended to be compatible with https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md[CloudEvents distributed tracing extension].
+
+[.specitem,oft-sid="req~up-attributes-traceparent~1",oft-needs="impl,utest"]
+--
+* *MAY* contain traceparent attribute.
+--
+
 
 |`payload format`
 |link:upayloadformat.adoc[UPayloadFormat]
 |no
-|The format of the payload (data).
+a|The format of the payload (data).
+[.specitem,oft-sid="req~up-attributes-payload-format~1",oft-needs="impl,utest"]
+--
+* *MAY* contain payload format attribute.
+--
 
 |===
 
@@ -96,13 +124,31 @@ The following table defines attributes that are used for publish messages in add
 
 |`type`
 |yes
-|*MUST* be set to `UMESSAGE_TYPE_PUBLISH`.
+a| 
+[.specitem,oft-sid="req~up-attributes-publish-type~1",oft-needs="impl,utest"]
+--
+*MUST* be set to `UMESSAGE_TYPE_PUBLISH`.
+--
 
 |`source`
 |yes
 a|A link:uri.adoc[UUri] representing the topic that this message is published to.
 
+[.specitem,oft-sid="req~up-attributes-publish-source~1",oft-needs="impl,utest"]
+--
 * The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFE]`.
+--
+
+|`sink`
+|no
+a|A link:uri.adoc[UUri] representing the receiver of this published message. This information is 
+only required when we are sending the published event between devices through the streamer, publishers are not required to populate this information.
+
+[.specitem,oft-sid="req~up-attributes-publish-sink~1",oft-needs="impl,utest"]
+--
+* *MAY* be present in the message. If present, the UUri *MUST* only contain the `authority_name` field.
+--
+
 |===
 
 [#notification-attributes]
@@ -116,19 +162,29 @@ The following table defines attributes that are used for notification messages i
 
 |`type`
 |yes
-|*MUST* be set to `UMESSAGE_TYPE_NOTIFICATION`.
-
+a|
+[.specitem,oft-sid="req~up-attributes-notification-type~1",oft-needs="impl,utest"]
+--
+*MUST* be set to `UMESSAGE_TYPE_NOTIFICATION`.
+--
 |`source`
 |yes
-a|A link:uri.adoc[UUri] representing the component that this notification originates from.
+a|
+A link:uri.adoc[UUri] representing the component that this notification originates from.
 
+[.specitem,oft-sid="req~up-attributes-notification-source~1",oft-needs="impl,utest"]
+--
 * The UUri's `resource_id` *MUST* be set to a value in range `[0x8000, 0xFFFE]`.
+--
 
 |`sink`
 |yes
 a|A link:uri.adoc[UUri] representing the receiver of this notification.
 
+[.specitem,oft-sid="req~up-attributes-notification-sink~1",oft-needs="impl,utest"]
+--
 * The UUri's `resource_id` *MUST* be set to `0`.
+--
 
 |===
 
@@ -143,40 +199,66 @@ The following table defines attributes that are used for RPC request messages in
 
 |`type`
 |yes
-|*MUST* be set to `UMESSAGE_TYPE_REQUEST`.
+a|
+[.specitem,oft-sid="req~up-attributes-request-type~1",oft-needs="impl,utest"]
+--
+*MUST* be set to `UMESSAGE_TYPE_REQUEST`.
+--
 
 |`source`
 |yes
 a|The link:uri.adoc[UUri] that the service consumer expects to receive the response message at.
 
+[.specitem,oft-sid="req~up-attributes-request-source~1",oft-needs="impl,utest"]
+--
 * The UUri's `resource_id` *MUST* be set to `0`.
+--
 
 |`sink`
 |yes
 a|A link:uri.adoc[UUri] identifying the service provider's method to invoke.
 
+[.specitem,oft-sid="req~up-attributes-request-sink~1",oft-needs="impl,utest"]
+--
 * The UUri's `resource_id` *MUST* be set to a value in range `[1, 0x7FFF]`.
+--
 
 |`priority`
 |yes
 a|The link:qos.adoc[QoS] level that this message should be processed/delivered with.
 
+[.specitem,oft-sid="req~up-attributes-request-priority~1",oft-needs="impl,utest"]
+--
 * *MUST* be set to `UPRIORITY_CS4` or higher.
+--
 
 |`ttl`
 |yes
 a|The amount of time (in milliseconds) after which this request message should no longer be delivered to or processed by a service provider.
 
+[.specitem,oft-sid="req~up-attributes-request-ttl~1",oft-needs="impl,utest"]
+--
 * *MUST* be set to a value > 0
-
+--
 
 |`permission_level`
 |no
-|The service consumer's permission level as defined in link:permissions.adoc#_code_based_access_permissions_caps[Code-Based uE Access Permissions (CAPs)].
+a|The service consumer's permission level as defined in link:permissions.adoc#_code_based_access_permissions_caps[Code-Based uE Access Permissions (CAPs)].
+
+[.specitem,oft-sid="req~up-attributes-permission-level~1",oft-needs="impl,utest"]
+--
+* *MAY* contain permission level attribute.
+--
 
 |`token`
 |no
-|The service consumer's access token as defined in link:permissions.adoc#_token_based_access_permissionstaps[Token-Based uE Access Permissions (TAPs)].
+a|The service consumer's access token as defined in link:permissions.adoc#_token_based_access_permissionstaps[Token-Based uE Access Permissions (TAPs)].
+
+[.specitem,oft-sid="req~up-attributes-request-token~1",oft-needs="impl,utest"]
+--
+* *MAY* contain token attribute.
+--
+
 |===
 
 [#response-attributes]
@@ -190,19 +272,29 @@ The following table defines attributes that are used for RPC response messages i
 
 |`type`
 |yes
-|*MUST* be set to `UMESSAGE_TYPE_RESPONSE`.
+a|
+[.specitem,oft-sid="req~up-attributes-response-type~1",oft-needs="impl,utest"]
+--
+*MUST* be set to `UMESSAGE_TYPE_RESPONSE`.
+--
 
 |`source`
 |yes
 a|The link:uri.adoc[UUri] identifying the method that has been invoked and which this message is the outcome of.
 
+[.specitem,oft-sid="req~up-attributes-response-source~1",oft-needs="impl,utest"]
+--
 * The UUri's `resource_id` *MUST* be set to a value in range `[1, 0x7FFF]`.
+--
 
 |`sink`
 |yes
 a|The link:uri.adoc[UUri] that the service consumer expects to receive this response message at.
 
+[.specitem,oft-sid="req~up-attributes-response-sink~1",oft-needs="impl,utest"]
+--
 * The UUri's `resource_id` *MUST* be set to `0`.
+--
 
 |`reqid`
 |yes
@@ -210,19 +302,32 @@ a|The link:uri.adoc[UUri] that the service consumer expects to receive this resp
 
 |`priority`
 |yes
-|The link:qos.adoc[QoS] level that this message should be processed/delivered with. *MUST* be the same value as that of the corresponding request message's `priority` attribute.
+a|
+The link:qos.adoc[QoS] level that this message should be processed/delivered with. 
+
+[.specitem,oft-sid="req~up-attributes-response-reqid~1",oft-needs="impl,utest"]
+--
+* *MUST* be the same value as that of the corresponding request message's `priority` attribute.
+--
 
 |`ttl`
 |no
-|The amount of time after which this response message should no longer be delivered to or processed by the service consumer.
+a|
+The amount of time after which this response message should no longer be delivered to or processed by the service consumer.
+
+[.specitem,oft-sid="req~up-attributes-response-ttl~1",oft-needs="impl,utest"]
+--
+* *MUST* be the same value as that of the corresponding request message's `ttl` attribute.
+--
 
 |`commstatus`
 |no
-|A link:../up-core-api/uprotocol/v1/ustatus.proto[UCode] indicating an error that has occurred during the delivery of either the RPC request or response message. A value of `0` or no value indicates that no communication error has occurred.
+a|A link:../up-core-api/uprotocol/v1/ustatus.proto[UCode] indicating an error that has occurred during the delivery of either the RPC request or response message. A value of `0` or no value indicates that no communication error has occurred.
+
+[.specitem,oft-sid="req~up-attributes-response-commstatus~1",oft-needs="impl,utest"]
+--
+* *MUST* contain commstatus attribute if the request message was not delivered successfully or the server was unable to process the request.
+--
 
 |===
 
-
-== Validation
-
-Each link:../languages.adoc[uProtocol Language Library] *MUST* provide means to assert the consistency of a message's attributes according to its type as defined in the sections above. The concrete implementation should follow common practices of the particular programming language.

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -34,9 +34,9 @@ The reason for the different configurations is that cloud MQTT brokers often hav
 
 MQTT 5 supports custom header fields, and we leverage this to map the `UAttributes` values into the `UserProperty` MQTT header in string format.
 
-[.specitem,oft-sid="req~up-transport-mqtt5-attributes~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="req~up-transport-mqtt5-attributes-non-empty~1",oft-needs="impl,utest"]
 --
-* `UserProperty` Keys *MUST* map to the UAttributes protobuf field numbers.
+* Only non-empty attribute values *MUST* be mapped to MQTT header `UserProperty` keys.
 --
 
 .uAttributes Mapping to MQTT5 User Properties
@@ -183,7 +183,7 @@ When a message is sent from one uE to another uE, the topic is constructed using
 
 [.specitem,oft-sid="req~up-transport-mqtt5-ue2ue-topic~1",oft-needs="impl,utest"]
 --
-`{UAttributes.source}/{UAttributes.sink}/`
+`{UAttributes.source}/{UAttributes.sink}`
 --
 
 [.specitem,oft-sid="req~up-transport-mqtt5-ue2ue-topic-nosink~1",oft-needs="impl,utest"]

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -28,7 +28,7 @@ This document will discuss the uTransport implementation on MQTT 5 for two well 
 1. *Device-2-Device (D2D) Communication:* This is when devices (through the streamer) was to send messages to other devices through a cloud gateway (broker). 
 2. *uE-2-uE Communication:* When MQTT is used as a local software bus for uEs to talk to each other through a local broker.
 
-The reason fo the different configurations is that cloud MQTT brokers often have limitations on the number of topics that can be subscribed to as well as the topic segment lengths so we need to ensure that message routing is as efficient as possible.
+The reason for the different configurations is that cloud MQTT brokers often have limitations on the number of topics that can be subscribed to as well as the topic segment lengths so we need to ensure that message routing is as efficient as possible.
 
 == MQTT5 Header
 

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -24,165 +24,215 @@ MQTT is an OASIS standard messaging protocol for the Internet of Things (IoT). I
 
 For more information, please refer to https://mqtt.org/
 
-This document will discuss the uTransport implementation on MQTT 5.
+This document will discuss the uTransport implementation on MQTT 5 for two well known use cases:
+1. *Device-2-Device (D2D) Communication:* This is when devices (through the streamer) was to send messages to other devices through a cloud gateway (broker). 
+2. *uE-2-uE Communication:* When MQTT is used as a local software bus for uEs to talk to each other through a local broker.
 
-== Specifications
+The reason fo the different configurations is that cloud MQTT brokers often have limitations on the number of topics that can be subscribed to as well as the topic segment lengths so we need to ensure that message routing is as efficient as possible.
 
-=== UAttributes Mapping
+== MQTT5 Header
 
-MQTT 5 supports custom header fields, and we leverage this to map the UAttributes values into the MQTT header.
+MQTT 5 supports custom header fields, and we leverage this to map the `UAttributes` values into the `UserProperty` MQTT header in string format.
 
-[cols="1,1,1,1"]
+[.specitem,oft-sid="req~up-transport-mqtt5-attributes~1",oft-needs="impl,utest"]
+--
+* `UserProperty` Keys *MUST* map to the UAttributes protobuf field numbers.
+--
+
+.uAttributes Mapping to MQTT5 User Properties
+[cols="1,2,5"]
 |===
-| MQTT Header Property Code | Value (key:value) | Value Type | Description
+| key |value | Description
 
-| UserProperty
-| ("0", "{UAttributes Version}")
-| String
+| "0"
+| "1"
 a| The version of the UAttributes protobuf
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-version~1",oft-needs="impl,utest"]
+--
+* *MUST* represent the major version of the UAttributes protobuf. Currently should be set to `1`.
+--
 
-* MUST represent the major version of the UAttributes protobuf. Currently should be set to `1`.
-
-| UserProperty
-| ("1", "{UAttributes.id}")
-| String
+| "1"
+| "{UAttributes.id}"
 a| Unique identifier for the message
 
-* MUST be set to the https://www.rfc-editor.org/rfc/rfc4122.html#section-3[hyphenated string representation] of the UUID.
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-id~1",oft-needs="impl,utest"]
+--
+* *MUST* be set to the https://www.rfc-editor.org/rfc/rfc4122.html#section-3[hyphenated string representation] of the UUID.
+--
 
-| UserProperty
-| ("2", "{UAttributes.type}")
-| String
+| "2"
+| "{UAttributes.type}"
 a| The type of message
 
-* MUST be the enum value for UAttributes.type link:../up-core-api/uprotocol/v1/uattributes.proto[UMessageType enum].
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-type~1",oft-needs="impl,utest"]
+--
+* *MUST* be the enum value for `UAttributes.type` link:../up-core-api/uprotocol/v1/uattributes.proto[UMessageType enum].
+--
 
-| UserProperty
-| ("3","{UAttributes.source}")
-| String
+| "3"
+| "{UAttributes.source}"
 a| The origin (address) of the message
 
-* MUST be the link:../basics/uri.adoc[string serialization of the UUri]
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-source~1",oft-needs="impl,utest"]
+--
+* *MUST* be the link:../basics/uri.adoc[string serialization of the UUri]
+--
 
-| UserProperty
-| ("4","{UAttributes.sink}")
-| String
+| "4"
+| "{UAttributes.sink}"
 a| The destination (address) of the message
 
-* MUST be the link:../basics/uri.adoc[string serialization of the UUri]
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-sink~1",oft-needs="impl,utest"]
+--
+* *MUST* be the link:../basics/uri.adoc[string serialization of the UUri]
+--
 
-| UserProperty
-| ("5","{UAttributes.priority}")
-| String
+| "5"
+| "{UAttributes.priority}"
 a| The message's priority as defined in link:../basics/qos.adoc[QoS doc]
 
-* MUST be set to the enum value for UAttributes.priority link:../up-core-api/uprotocol/v1/uattributes.proto[UPriority enum].
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-priority~1",oft-needs="impl,utest"]
+--
+* *MUST* be set to the enum value for UAttributes.priority link:../up-core-api/uprotocol/v1/uattributes.proto[UPriority enum].
+--
 
-| UserProperty
-| ("6", "{UAttributes.ttl}")
-| String
+| "6"
+| "{UAttributes.ttl}"
 a| The amount of time (in milliseconds) after which this message MUST NOT be delivered/processed anymore
+    
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-ttl~1",oft-needs="impl,utest"]
+--
+* *MUST* be set to the TTL value in milliseconds as a string.
+--
 
-| UserProperty
-| ("7", "{UAttributes.permissionLevel}")
-| String
+| "7"
+| "{UAttributes.permissionLevel}"
 a| The service consumer's permission level as defined in link:../up-l2/permissions.adoc#_code_based_access_permissions_caps[Code-Based uE Access Permissions (CAPs)]
 
-| UserProperty
-| ("8", "{UAttributes.commStatus}")
-| String
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-permission-level~1",oft-needs="impl,utest"]
+--
+* *MUST* be set to the link:../up-l2/permissions.adoc#_code_based_access_permissions_caps[CAPs]'s integer value as a string. 
+--
+
+| "8" 
+| "{UAttributes.commStatus}"
 a| A UCode indicating an error that has occurred during the delivery of either an RPC Request or Response message
 
-* MUST be set to the link:../up-core-api/uprotocol/v1/ustatus.proto[UCode]'s integer value as a string.
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-comm-status~1",oft-needs="impl,utest"]
+--
+* *MUST* be set to the link:../up-core-api/uprotocol/v1/ustatus.proto[UCode]'s integer value as a string.
+--
 
-| UserProperty
-| ("9", "{UAttributes.reqId}")
-| String
-a| The identifier that a service consumer can use to correlate an RPC Repsonse message with its RPC Request
+| "9"
+| "{UAttributes.reqId}"
+a| The identifier that a service consumer can use to correlate an RPC response message with its RPC request
 
-* MUST be set to the https://www.rfc-editor.org/rfc/rfc4122.html#section-3[hyphenated string representation] of the UUID.
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-req-id~1",oft-needs="impl,utest"]
+--
+* *MUST* be set to the https://www.rfc-editor.org/rfc/rfc4122.html#section-3[hyphenated string representation] of the UUID.
+--
 
-| UserProperty
-| ("10", "{UAttributes.token}")
-| String
+| "10"
+| "{UAttributes.token}"
 a| The service consumer's access token
 
-| UserProperty
-| ("11", "{UAttributes.traceParent}")
-| String
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-token~1",oft-needs="impl,utest"]
+--
+* *MUST* be the token value as a string.
+--
+
+| "11"
+| "{UAttributes.traceparent}"
 a| A tracing identifier to use for correlating messages across the system
 
-| UserProperty
-| ("12", "{UAttributes.payload_format}")
-| String
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-traceparent~1",oft-needs="impl,utest"]
+--
+* *MUST* be set to the traceparent value as a string.
+--
+
+| "12"
+| "{UAttributes.payload_format}"
 a| The format for the data stored in the UMessage
 
-* MUST be set to the enum value for UAttributes.payload_format link:../up-core-api/uprotocol/v1/uattributes.proto[UPayloadFormat enum].
+[.specitem,oft-sid="req~up-transport-mqtt5-attribute-payload-format~1",oft-needs="impl,utest"]
+--
+* *MUST* be set to the enum value for UAttributes.payload_format link:../up-core-api/uprotocol/v1/uattributes.proto[UPayloadFormat enum].
+--
 
 |===
 
 All uAttributes are mapped to a MQTT header UserProperty, where the key is the UAttributes protobuf field number. The value is a string representation of the UAttributes field. Only UAttributes that are used in the message are included in the MQTT header. If a UAttributes field is not present in the header, than it is considered not used when recompiling the UAttributes.
 
-=== URI Mapping to MQTT topics
+== Payload Encoding
 
-The MQTT topic a message is published on utilizes the source and sink UUri fields.
+[.specitem,oft-sid="req~up-transport-mqtt5-payload-encoding~1",oft-needs="impl,utest"]
+--
+* The MQTT payload **MUST** be the `UMessage.payload` field, which is a byte array to reduce size.
+--
 
-`{client_identifier}/{source.authority_name}/{source.ue_id}/{source.ue_version_major}/{source.resource_id}/{sink.authority_name}/{sink.ue_id}/{sink.ue_version_major}/{sink.resource_id}`
 
-If the no sink uuri is provided, then the topic sections using sink uuri segments are removed, like so:
+== MQTT5 Topics
 
-`{client_identifier}/{source.authority_name}/{source.ue_id}/{source.ue_version_major}/{source.resource_id}`
+The MQTT topic a message is published on utilizes the source and sink UUri fields. The topic is dependent on the use case for the transport implementation that will be discussed below.
 
-The client_identifier is used to determine where messages are coming from. The valid values for the client_identifier are:
 
-- `c` : Indicates that the message originated from the cloud
-- `d` : Indicates that the message originated from a device and is remote
+=== uE-2-uE Communication
 
-The client_identifier that is used for the topic is based on the kind of MQTT uTransport client that is sending the message. An MQTT uTransport client can be one of the following:
+When a message is sent from one uE to another uE, the topic is constructed using the source and sink UUri fields. The topic is constructed as follows using the string representation of a `UUri`:
 
-- Cloud MQTT uTransport client: A client that runs in the cloud.
-- Remote MQTT uTransport client: A client that runs on a device and is connected to a cloud MQTT broker.
+[.specitem,oft-sid="req~up-transport-mqtt5-ue2ue-topic~1",oft-needs="impl,utest"]
+--
+`{UAttributes.source}/{UAttributes.sink}/`
+--
 
-Below are examples of messages being sent and how to subscribe to those messages:
+[.specitem,oft-sid="req~up-transport-mqtt5-ue2ue-topic-nosink~1",oft-needs="impl,utest"]
+--
+If the messages does not have a sink `UUri`, then the sink portion of the MQTT5 topic *MUST* be omitted.
+--
 
-==== Remote uTransport Client Examples
+==== Examples
 
-How a source and sink UUri are mapped to an MQTT topic when the message is sent from a remote uTransport client:
-
-[cols="1,1,1"]
+.uE-2-uE Communication Topics
+[cols="1,2,2,4"]
 |===
-| source | sink | topic
+| Type| source URI | sink URI | MQTT5 Topic
 
-| //vehicle_1.veh.com/AB34/1/12CD | //vehicle_2.veh.com/43BA/1/DC21 | {cli_identifier}/vehicle_1.veh.com/AB34/1/12CD/vehicle_2.veh.com/43BA/1/DC21
-| //vehicle_1.veh.com/AB34/1/12CD | None | {cli_identifier}/vehicle_1.veh.com/AB34/1/12CD
+| *Request* | `//device1/AB34/1/0` | `//device1/43BA/1/2` | `device1/AB34/1/0/device1/43BA/1/2`
+| *Response* | `//device1/43BA/1/2` | `//device1/AB34/1/0` | `device1/43BA/1/2/device1/AB34/1/0`
+| *Publish* | `//device1/AB34/1/8000` | None | `device1/AB34/1/8000`
+| *Notification* | `//device1/43BA/1/8001` | `//device1/AB34/1/0` | `device1/43BA/1/8001/device1/AB34/1/0`
 |===
 
-Listener examples for a device:
 
+.uE-2-uE Communication UTransport::registerListener() Examples
 [cols="1,1,1,1"]
 |===
-| goal | source filter | sink filter | listener topic
+| Use Case | source filter | sink filter | MQTT Subscription
 
-| Subscribe to a specific Publish topic | //vehicle_1.veh.com/AB34/1/12CD | None | d/vehicle_1.veh.com/AB34/1/12CD
-| Subscribe to all incoming requests to a specific method | empty | //vehicle_1.veh.com/AB34/1/12CD | d/\+/+/\+/+/vehicle_1.veh.com/AB34/1/12CD
-| Subscribe to a specific Notification topic | //vehicle_2.veh.com/43BA/1/DC21 | //vehicle_1.veh.com/AB34/1/0 | d/vehicle_2.veh.com/43BA/1/DC21/vehicle_1.veh.com/AB34/1/0
-| Subscribe to all incoming messages to a UAuthority from the cloud | empty | //vehicle_1.veh.com/FFFF/FF/FFFF | c/\+/+/\+/+/vehicle_1.veh.com/\+/+/+
-| Subscribe to all publish messages from a different UAuthority | //vehicle_1.veh.com/FFFF/FF/FFFF | None | d/vehicle_1.veh.com/\+/+/+
-| Streamer subscribing to receive any sent notifications, requests, or responses to its device from the cloud | empty | //vehicle_1.veh.com/FFFF/FF/0 | c/\+/+/\+/+/vehicle_1.veh.com/\+/+/0
+| Single Publish Topic | `//device1/AB34/1/8000` | None | `device1/AB34/1/8000`
+| Incoming requests for a Method | empty | `//device1/AB34/1/12CD` | `\+/+/\+/+/device1/AB34/1/12CD`
+| Any Notifications or RPC Responses | empty | //device1/AB34/1/0 | `\+/+/\+/+/device1/AB34/1/0`
+
 |===
 
-==== Cloud uTransport Client Examples
 
-Shows how source and sink filters can be used to construct wildcard topics for listening to messages from many devices.
+=== D2D Communication
 
-[cols="1,1,1,1"]
-|===
-| goal | source filter | sink filter | listener topic
+D2D routing of messages only require the authority portion of the source and sink attributes for routing between devices so the MQTT5 topic shall be:
 
-| Subscribe to all publish messages from devices | empty | None | d/\+/+/\+/+
-| Subscribe to all message types but publish messages sent from a UAuthority | //vehicle_1.veh.com/FFFF/FF/FFFF | empty | d/vehicle_1.veh.com/\+/+/\+/+/\+/+/\+/+
-|===
+[.specitem,oft-sid="req~up-transport-mqtt5-d2d-topic~1",oft-needs="impl,utest"]
+--
+`{UAttributes.source.authority_name}/{UAttributes.sink.authority_name}`
+--
 
-=== Payload Encoding
+==== Examples
 
-The MQTT payload **MUST** be the UMessage.payload field, which is a byte array to reduce size.
+===== Registering Listener to Receive All Messages 
+`UTransport::registerListener(ANY, getSource())` where getSource(0 returns the local device's UUri, this translates into the MQTT subscribe to topic `+/{my_source_authority_name}`
+
+===== Sending a Message
+`UTransport::send(UMessage)` translates to the MQTT publish to topic `{UMessage.source.authority_name}/{UMessage.sink.authority_name}`
+
+
+

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -36,7 +36,8 @@ MQTT 5 supports custom header fields, and we leverage this to map the `UAttribut
 
 [.specitem,oft-sid="req~up-transport-mqtt5-attributes-non-empty~1",oft-needs="impl,utest"]
 --
-* Only non-empty attribute values *MUST* be mapped to MQTT header `UserProperty` keys.
+* All non-empty attribute values *MUST* be mapped to MQTT header *User Properties* using the keys defined below.
+* Empty attribute values *MUST NOT* be mapped.
 --
 
 .uAttributes Mapping to MQTT5 User Properties

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -230,7 +230,7 @@ When MQTT5 (broker) is used for D2D communication, the topic shall consist of on
 ==== Examples
 
 ===== Registering Listener to Receive All Messages 
-`UTransport::registerListener(ANY, getSource())` where getSource(0 returns the local device's UUri, this translates into the MQTT subscribe to topic `+/{my_source_authority_name}`
+`UTransport::registerListener(ANY, getSource())` where getSource() returns the local device's UUri, this translates into the MQTT subscribe to topic `+/{my_source_authority_name}`
 
 ===== Sending a Message
 `UTransport::send(UMessage)` translates to the MQTT publish to topic `{UMessage.source.authority_name}/{UMessage.sink.authority_name}`

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -180,11 +180,11 @@ The MQTT topic a message is published on utilizes the source and sink UUri field
 
 === uE-2-uE Communication
 
-When a message is sent from one uE to another uE, the topic is constructed using the source and sink UUri fields. The topic is constructed as follows using the string representation of a `UUri`:
+When MQTT5 (broker) is used for local (within a device) uE-2-uE communication, the topic shall consist of the entire source and sink `UUri` from `UAttributes` as shown below:
 
 [.specitem,oft-sid="req~up-transport-mqtt5-ue2ue-topic~1",oft-needs="impl,utest"]
 --
-`{UAttributes.source}/{UAttributes.sink}`
+`{source.authority_name}/{source.ue_id}/{source.ue_version_major}/{source.resource_id}/{sink.authority_name}/{sink.ue_id}/{sink.ue_version_major}/{sink.resource_id}`
 --
 
 [.specitem,oft-sid="req~up-transport-mqtt5-ue2ue-topic-nosink~1",oft-needs="impl,utest"]
@@ -220,11 +220,11 @@ If the messages does not have a sink `UUri`, then the sink portion of the MQTT5 
 
 === D2D Communication
 
-D2D routing of messages only require the authority portion of the source and sink attributes for routing between devices so the MQTT5 topic shall be:
+When MQTT5 (broker) is used for D2D communication, the topic shall consist of only the authority portion of the source and sink `UUri` from `UAttributes` as shown below:
 
 [.specitem,oft-sid="req~up-transport-mqtt5-d2d-topic~1",oft-needs="impl,utest"]
 --
-`{UAttributes.source.authority_name}/{UAttributes.sink.authority_name}`
+`{source.authority_name}/{sink.authority_name}`
 --
 
 ==== Examples


### PR DESCRIPTION
The following changes adds D2D usecase for the MQTT5 transport, fixes the uE-2-uE use case, and adds OFT tags to uatributes and MQTT5 specs.

#192, #169