### PR TITLE
Use stable Zenoh version 0.11.0 instead of RC.

### DIFF
--- a/up-l1/zenoh.adoc
+++ b/up-l1/zenoh.adoc
@@ -30,7 +30,7 @@ For more information, please visit https://projects.eclipse.org/projects/iot.zen
 
 === Zenoh Version
 
-We **MUST** use Zenoh version `0.11.0-rc.3` to ensure the interoperability in different language bindings.
+We **MUST** use Zenoh version `0.11.0` to ensure the interoperability in different language bindings.
 
 === UPClientZenoh initialization
 


### PR DESCRIPTION
I wasn't aware of the stable release of Zenoh 0.11.0 before. Using the stable one instead of the RC version would be better.