### PR TITLE
Use relative paths in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-/.idea/
-/.vscode/
-/uprotocol-spec.iml
-/up-spec.iml
-/up-core-api/target/
-/target/
+.idea/
+.vscode/
+uprotocol-spec.iml
+up-spec.iml
+up-core-api/target/
+target/


### PR DESCRIPTION
Changed all absolute paths in gitignore so that the paths are
also being ignored when including up-spec as a git submodule from
other repos (as we do from up-rust).