### PR TITLE
Adding OFT metadata and uTransport address spoofing check.

### DIFF
--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -122,6 +122,7 @@ On the other hand, unsuccessful completion of this method does not necessarily m
 
 NOTE: The above strategy for retrying failed attempts to send a message results in https://www.cloudcomputingpatterns.org/at_least_once_delivery/[at-least-once delivery]. Recipient(s) of these messages should therefore be https://www.cloudcomputingpatterns.org/idempotent_processor/[Idempotent Processors].
 
+*Requirements for UTransport Implementations:*
 
 [.specitem,oft-sid="dsn~utransport-send-preserve-data~1",oft-needs="impl,utest"]
 --
@@ -186,6 +187,8 @@ receive(sourceFilter: UUri, sinkFilter: UUri [0..1]) : UMessage
 
 This method implements the _pull_ <<delivery-method, delivery method>> on top of the underlying communication protocol.
 
+*Requirements for UTransport Implementations:*
+
 [.specitem,oft-sid="req~utransport-receive-error-unimplemented~1",oft-needs="impl,utest"]
 --
 * *MUST* return `UCode.UNIMPLEMENTED` if the transport does not support the _pull_ <<delivery-method, delivery method>>
@@ -246,6 +249,8 @@ registerListener(sourceFilter: UUri, sinkFilter: UUri [0..1], listener: UListene
 
 This API is used to implement the _push_ <<delivery-method, delivery method>> on top of the underlying communication protocol.
 After this method has completed successfully, the given listener will be invoked for each message that matches the given source and sink filter patterns according to the rules defined by the link:../basics/uri.adoc[UUri specification].
+
+*Requirements for UTransport Implementations:*
 
 [.specitem,oft-sid="req~utransport-registerlistener-error-unimplemented~1",oft-needs="impl,utest"]
 --
@@ -477,13 +482,5 @@ uProtocol defines bindings to the following communication protocols:
 * link:mqtt_5.adoc[*MQTT*]
 * link:http.adoc[*HTTP*]
 * link:someip.adoc[*SOME/IP*]
-
-
-If a communication protocol binding uses link:https://cloudevents.io/[CloudEvents]:
-
-[.specitem,oft-sid="dsn~utransport-cloudevents~1",oft-needs="impl,utest"]
---
-* *MUST* adhere to link:cloudevents.adoc[*UMessage mapping to CloudEvents*]
---
 
 

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -129,12 +129,12 @@ NOTE: The above strategy for retrying failed attempts to send a message results 
 * *MUST* preserve all of the message's meta data and payload during transmission
 --
 
-[.specitem,oft-sid="req~utransport-send-error-invalid-parameter~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-send-error-invalid-parameter~1",oft-needs="impl,utest"]
 --
 * *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UMessage failed validation
 --
 
-[.specitem,oft-sid="req~utransport-send-error-permission-denied~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="req~utransport-send-error-permission-denied~1",oft-needs="dsn"]
 --
 * *MUST* fail with a `UCode.PERMISSION_DENIED` if a non-streamer client tries to send a message with `UAttributes.source` that is different than the source address associated with the transport, this is to avoid address spoofing.
 --
@@ -189,12 +189,12 @@ This method implements the _pull_ <<delivery-method, delivery method>> on top of
 
 *Requirements for UTransport Implementations:*
 
-[.specitem,oft-sid="req~utransport-receive-error-unimplemented~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-receive-error-unimplemented~1",oft-needs="impl,utest"]
 --
 * *MUST* return `UCode.UNIMPLEMENTED` if the transport does not support the _pull_ <<delivery-method, delivery method>>
 --
 
-[.specitem,oft-sid="req~utransport-receive-error-notfound~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-receive-error-notfound~1",oft-needs="impl,utest"]
 --
 * *MUST* return a `UCode.NOT_FOUND` if there are no matching messages available
 --
@@ -252,12 +252,12 @@ After this method has completed successfully, the given listener will be invoked
 
 *Requirements for UTransport Implementations:*
 
-[.specitem,oft-sid="req~utransport-registerlistener-error-unimplemented~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-registerlistener-error-unimplemented~1",oft-needs="impl,utest"]
 --
 * *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method, delivery method>>. In that case, the <<unregister-listener, unregisterListener>> method *MUST* also fail accordingly.
 --
 
-[.specitem,oft-sid="req~utransport-registerlistener-error-resource-exhausted~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-registerlistener-error-resource-exhausted~1",oft-needs="impl,utest"]
 --
 * *MUST* fail with a `UCode.RESOURCE_EXHAUSTED`, if the maximum number of listeners is reached
 --
@@ -372,17 +372,17 @@ unregisterListener(sourceFilter: UUri, sinkFilter: UUri [0..1], listener: UListe
 | The listener to be unregistered.
 |===
 
-[.specitem,oft-sid="req~utransport-unregisterlistener-error-unimplemented~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-unimplemented~1",oft-needs="impl,utest"]
 --
 * *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method>>. In that case, the <<register-listener>> method *MUST* also fail accordingly.
 --
 
-[.specitem,oft-sid="req~utransport-unregisterlistener-error-notfound~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-notfound~1",oft-needs="impl,utest"]
 --
 * *MUST* fail with a `UCode.NOT_FOUND`, if no such listener had been registered before
 --
 
-[.specitem,oft-sid="req~utransport-unregisterlistener-error-invalid-parameter~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-invalid-parameter~1",oft-needs="impl,utest"]
 --
 * *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UUri failed validation
 --

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -123,7 +123,7 @@ On the other hand, unsuccessful completion of this method does not necessarily m
 NOTE: The above strategy for retrying failed attempts to send a message results in https://www.cloudcomputingpatterns.org/at_least_once_delivery/[at-least-once delivery]. Recipient(s) of these messages should therefore be https://www.cloudcomputingpatterns.org/idempotent_processor/[Idempotent Processors].
 
 
-[.specitem,oft-sid="des~utransport-send-preserve-data~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-send-preserve-data~1",oft-needs="impl,utest"]
 --
 * *MUST* preserve all of the message's meta data and payload during transmission
 --
@@ -262,17 +262,17 @@ After this method has completed successfully, the given listener will be invoked
 * *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UUri failed validation
 --
 
-[.specitem,oft-sid="req~utransport-registerlistener-number-of-listeners~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-registerlistener-number-of-listeners~1",oft-needs="impl,utest"]
 --
 * *MUST* support registering more than one listener for any given address patterns
 --
   
-[.specitem,oft-sid="req~utransport-registerlistener-listener-reuse~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-registerlistener-listener-reuse~1",oft-needs="impl,utest"]
 --
 * *MUST* support registering the same listener for multiple address patterns
 --
 
-[.specitem,oft-sid="dsn~utransport-registerlistener-max-listeners~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="req~utransport-registerlistener-max-listeners~1",oft-needs="uman"]
 --
 * *MUST* document the maximum supported number of listeners per address pattern.
 --
@@ -415,7 +415,7 @@ A `UTransport` implementation can use the `LocalUriProvider` to determine the uE
 
 A uEntity invokes this method to get its own authority.
 
-[.specitem,oft-sid="req~utransport-localuriprovider-getauthority~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="req~utransport-localuriprovider-getauthority~1",oft-needs="dsn"]
 --
 Implementations *MAY* use any appropriate mechanism to determine the local authority during runtime, e.g. by means of a configuration file, environment variables or a central registry.
 --
@@ -424,12 +424,12 @@ Implementations *MAY* use any appropriate mechanism to determine the local autho
 
 A uEntity invokes this method to get the address that it expects incoming Notification or RPC Response messages to be sent to.
 
-[.specitem,oft-sid="req~utransport-localuriprovider-getsource-uri-segments~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-localuriprovider-getsource-uri-segments~1",oft-needs="impl,utest"]
 --
 The address returned by an implementation *MUST* consist of the uEntity's (fixed) _authority_, _identifier_ and _major version_ and _resource ID_ `0x0000`.
 --
 
-[.specitem,oft-sid="req~utransport-localuriprovider-getsource-runtime~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="req~utransport-localuriprovider-getsource-runtime~1",oft-needs="dsn"]
 --
 Implementations *MAY* use any appropriate mechanism to determine these values during runtime, e.g. by means of a configuration file, environment variables or a central registry.
 --
@@ -438,12 +438,12 @@ Implementations *MAY* use any appropriate mechanism to determine these values du
 
 A uEntity invokes this method to get a resource specific address to publish messages to or that it expects incoming RPC Request messages to be sent to.
 
-[.specitem,oft-sid="req~utransport-localuriprovider-getresource~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-localuriprovider-getresource~1",oft-needs="impl,utest"]
 --
 The address returned by an implementation *MUST* consist of the uEntity's (fixed) _authority_, _identifier_ and _major version_ and the passed in _resource ID_.
 --
   
-[.specitem,oft-sid="req~utransport-localuriprovider-getresource-runtime~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="req~utransport-localuriprovider-getresource-runtime~1",oft-needs="dsn"]
 --
 Implementations *MAY* use any appropriate mechanism to determine these values during runtime, e.g. by means of a configuration file, environment variables or a central registry.
 --
@@ -456,7 +456,7 @@ Implementations *MAY* use any appropriate mechanism to determine these values du
 * *MUST* support at least one of _push_ or _pull_ delivery methods and *MAY* support both
 --
   
-[.specitem,oft-sid="req~utransport-delivery-methods-docs~1",oft-needs="impl"]
+[.specitem,oft-sid="req~utransport-delivery-methods-docs~1",oft-needs="uman"]
 --
 * *MUST* document the delivery methods they support
 --

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -122,9 +122,21 @@ On the other hand, unsuccessful completion of this method does not necessarily m
 
 NOTE: The above strategy for retrying failed attempts to send a message results in https://www.cloudcomputingpatterns.org/at_least_once_delivery/[at-least-once delivery]. Recipient(s) of these messages should therefore be https://www.cloudcomputingpatterns.org/idempotent_processor/[Idempotent Processors].
 
-UTransport implementations
 
+[.specitem,oft-sid="des~utransport-send-preserve-data~1",oft-needs="impl,utest"]
+--
 * *MUST* preserve all of the message's meta data and payload during transmission
+--
+
+[.specitem,oft-sid="req~utransport-send-error-invalid-parameter~1",oft-needs="impl,utest"]
+--
+* *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UMessage failed validation
+--
+
+[.specitem,oft-sid="req~utransport-send-error-permission-denied~1",oft-needs="impl,utest"]
+--
+* *MUST* fail with a `UCode.PERMISSION_DENIED` if a non-streamer client tries to send a message with `UAttributes.source` that is different than the source address associated with the transport, this is to avoid address spoofing.
+--
 
 [mermaid]
 ifdef::env-github[[source,mermaid]]
@@ -174,10 +186,15 @@ receive(sourceFilter: UUri, sinkFilter: UUri [0..1]) : UMessage
 
 This method implements the _pull_ <<delivery-method, delivery method>> on top of the underlying communication protocol.
 
-UTransport implementations
+[.specitem,oft-sid="req~utransport-receive-error-unimplemented~1",oft-needs="impl,utest"]
+--
+* *MUST* return `UCode.UNIMPLEMENTED` if the transport does not support the _pull_ <<delivery-method, delivery method>>
+--
 
-* *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _pull_ <<delivery-method, delivery method>>
-* *MUST* fail with a `UCode.NOT_FOUND` if there are no matching messages available
+[.specitem,oft-sid="req~utransport-receive-error-notfound~1",oft-needs="impl,utest"]
+--
+* *MUST* return a `UCode.NOT_FOUND` if there are no matching messages available
+--
 
 [mermaid]
 ifdef::env-github[[source,mermaid]]
@@ -230,14 +247,41 @@ registerListener(sourceFilter: UUri, sinkFilter: UUri [0..1], listener: UListene
 This API is used to implement the _push_ <<delivery-method, delivery method>> on top of the underlying communication protocol.
 After this method has completed successfully, the given listener will be invoked for each message that matches the given source and sink filter patterns according to the rules defined by the link:../basics/uri.adoc[UUri specification].
 
-UTransport implementations
-
+[.specitem,oft-sid="req~utransport-registerlistener-error-unimplemented~1",oft-needs="impl,utest"]
+--
 * *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method, delivery method>>. In that case, the <<unregister-listener, unregisterListener>> method *MUST* also fail accordingly.
+--
+
+[.specitem,oft-sid="req~utransport-registerlistener-error-resource-exhausted~1",oft-needs="impl,utest"]
+--
 * *MUST* fail with a `UCode.RESOURCE_EXHAUSTED`, if the maximum number of listeners is reached
+--
+
+[.specitem,oft-sid="req~utransport-registerlistener-error-invalid-parameter~1",oft-needs="impl,utest"]
+--
+* *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UUri failed validation
+--
+
+[.specitem,oft-sid="req~utransport-registerlistener-number-of-listeners~1",oft-needs="impl,utest"]
+--
 * *MUST* support registering more than one listener for any given address patterns
+--
+  
+[.specitem,oft-sid="req~utransport-registerlistener-listener-reuse~1",oft-needs="impl,utest"]
+--
 * *MUST* support registering the same listener for multiple address patterns
+--
+
+[.specitem,oft-sid="dsn~utransport-registerlistener-max-listeners~1",oft-needs="impl,utest"]
+--
 * *MUST* document the maximum supported number of listeners per address pattern.
+--
+
+[.specitem,oft-sid="dsn~utransport-registerlistener-idempotent~1",oft-needs="impl,utest"]
+--
 * *MUST* be idempotent, multiple calls to said API with the same parameters *MUST* have the same effect as a single call.
+--
+
 
 .Registering a Listener
 [mermaid]
@@ -323,10 +367,20 @@ unregisterListener(sourceFilter: UUri, sinkFilter: UUri [0..1], listener: UListe
 | The listener to be unregistered.
 |===
 
-UTransport implementations
-
+[.specitem,oft-sid="req~utransport-unregisterlistener-error-unimplemented~1",oft-needs="impl,utest"]
+--
 * *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method>>. In that case, the <<register-listener>> method *MUST* also fail accordingly.
+--
+
+[.specitem,oft-sid="req~utransport-unregisterlistener-error-notfound~1",oft-needs="impl,utest"]
+--
 * *MUST* fail with a `UCode.NOT_FOUND`, if no such listener had been registered before
+--
+
+[.specitem,oft-sid="req~utransport-unregisterlistener-error-invalid-parameter~1",oft-needs="impl,utest"]
+--
+* *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UUri failed validation
+--
 
 .Unregistering a Listener
 [mermaid]
@@ -361,31 +415,52 @@ A `UTransport` implementation can use the `LocalUriProvider` to determine the uE
 
 A uEntity invokes this method to get its own authority.
 
+[.specitem,oft-sid="req~utransport-localuriprovider-getauthority~1",oft-needs="impl,utest"]
+--
 Implementations *MAY* use any appropriate mechanism to determine the local authority during runtime, e.g. by means of a configuration file, environment variables or a central registry.
+--
 
 === GetSource
 
 A uEntity invokes this method to get the address that it expects incoming Notification or RPC Response messages to be sent to.
 
+[.specitem,oft-sid="req~utransport-localuriprovider-getsource-uri-segments~1",oft-needs="impl,utest"]
+--
 The address returned by an implementation *MUST* consist of the uEntity's (fixed) _authority_, _identifier_ and _major version_ and _resource ID_ `0x0000`.
+--
 
+[.specitem,oft-sid="req~utransport-localuriprovider-getsource-runtime~1",oft-needs="impl,utest"]
+--
 Implementations *MAY* use any appropriate mechanism to determine these values during runtime, e.g. by means of a configuration file, environment variables or a central registry.
+--
 
 === GetResource
 
 A uEntity invokes this method to get a resource specific address to publish messages to or that it expects incoming RPC Request messages to be sent to.
 
+[.specitem,oft-sid="req~utransport-localuriprovider-getresource~1",oft-needs="impl,utest"]
+--
 The address returned by an implementation *MUST* consist of the uEntity's (fixed) _authority_, _identifier_ and _major version_ and the passed in _resource ID_.
-
+--
+  
+[.specitem,oft-sid="req~utransport-localuriprovider-getresource-runtime~1",oft-needs="impl,utest"]
+--
 Implementations *MAY* use any appropriate mechanism to determine these values during runtime, e.g. by means of a configuration file, environment variables or a central registry.
+--
 
 [#delivery-method]
 == Message Delivery
 
-Transport API implementations
-
+[.specitem,oft-sid="dsn~utransport-delivery-methods~1",oft-needs="impl,utest"]
+--
 * *MUST* support at least one of _push_ or _pull_ delivery methods and *MAY* support both
+--
+  
+[.specitem,oft-sid="req~utransport-delivery-methods-docs~1",oft-needs="impl"]
+--
 * *MUST* document the delivery methods they support
+--
+
 
 == Communication Protocol Binding
 
@@ -403,11 +478,12 @@ uProtocol defines bindings to the following communication protocols:
 * link:http.adoc[*HTTP*]
 * link:someip.adoc[*SOME/IP*]
 
-Each uProtocol Client *MUST* employ exactly one of these bindings for implementing the Transport Layer API.
 
-Additional bindings *MAY* be defined in future versions of uProtocol.
+If a communication protocol binding uses link:https://cloudevents.io/[CloudEvents]:
 
-A binding *MAY* employ link:https://cloudevents.io/[CloudEvents] as a means to map uProtocol messages to the communication protocol's PDU. In order to provide for consistency across implementations, such bindings *MUST* adhere to link:cloudevents.adoc[*UMessage mapping to CloudEvents*]
-
+[.specitem,oft-sid="dsn~utransport-cloudevents~1",oft-needs="impl,utest"]
+--
+* *MUST* adhere to link:cloudevents.adoc[*UMessage mapping to CloudEvents*]
+--
 
 


### PR DESCRIPTION
The transport needs to verify that the caller (client) source address is the same as what is in the passed `UMessage` of the send() API to avoid any uE from spoofing another uE.  The only exception for this rule is if the uE is the streamer who is simply forwarding events from one transport to the next and in that case the streamers identity needs to be verified upon creation of the transport.

The PR also adds in missing OFT metadata.

#218