### PR TITLE
Bump Zenoh to 1.0.0-alpha.6

### DIFF
--- a/up-l1/zenoh.adoc
+++ b/up-l1/zenoh.adoc
@@ -30,7 +30,7 @@ For more information, please visit https://projects.eclipse.org/projects/iot.zen
 
 === Zenoh Version
 
-We **MUST** use Zenoh version `0.11.0` to ensure the interoperability in different language bindings.
+We **MUST** use Zenoh version `1.0.0-alpha.6` to ensure the interoperability in different language bindings.
 
 === UPClientZenoh initialization
 


### PR DESCRIPTION
Since most of the APIs are stable now, it's time to move forward to the Zenoh 1.0 version.
Loop @neelam-kushwah @PLeVasseur @sashacmc @stevenhartley