### PR TITLE
Remove unused SubscriberInfo from some USubscription messages

### DIFF
--- a/up-core-api/uprotocol/core/usubscription/v3/usubscription.proto
+++ b/up-core-api/uprotocol/core/usubscription/v3/usubscription.proto
@@ -120,8 +120,9 @@ message SubscriberInfo {
   // uE subscribing. Example represented in long form: `//device.domain/com.gm.app.hartley`
   uprotocol.v1.UUri uri = 1;
 
-  // Any additional device specific subscriber information
-  repeated google.protobuf.Any details = 2;
+  // DEPRECATED: Any additional device specific subscriber information
+  // repeated google.protobuf.Any details = 2;
+  reserved 2;
 }
 
 
@@ -171,8 +172,9 @@ message SubscriptionRequest {
   // uProtocol uri topic to subscribe too
   uprotocol.v1.UUri topic = 1;
 
-  // Subscribers's information (who is calling Subscribe)
-  SubscriberInfo subscriber = 2;
+  // DEPRECATED: Subscribers's information (who is calling Subscribe) is not needed
+  //SubscriberInfo subscriber = 2;
+  reserved 2;
 
   // Additional subscription attributes
   SubscribeAttributes attributes = 3;
@@ -199,8 +201,9 @@ message UnsubscribeRequest {
   // Topic to be unsubscribed to
   uprotocol.v1.UUri topic = 1;
 
-  // Subscriber identification
-  SubscriberInfo subscriber = 2;
+  // DEPRECATED 0Subscriber identification is not needed
+  // SubscriberInfo subscriber = 2;
+  reserved 2;
 }
 
 // The (empty) response message representing the successful execution of the Unsubscribe operation.
@@ -281,8 +284,10 @@ message NotificationsRequest {
   // Topic to register/unregister to receive subscription change notifications
   uprotocol.v1.UUri topic = 1;
 
-  // Subscribers's information
-  SubscriberInfo subscriber = 2;
+  // DEPRECATED: Subscribers's information not used as only non-subscribers will call
+  // this API (i.e. producers)
+  // SubscriberInfo subscriber = 2;
+  reserved 2;
 }
 
 // The (empty) response message representing the successful execution of the


### PR DESCRIPTION
The SubscriberInfo was a wrapper for the subscribers URI however it passes details that was never used (and complicates the implementations) and is passed in some scenarios that is redundant (we know who is calling the APIs). The SubscriberInfo is also passed to registerForNotifications however subscribers don't call this API so it is confusing for developers.

#220