### PR TITLE
Change OFT spec item revision

### DIFF
--- a/basics/uri.adoc
+++ b/basics/uri.adoc
@@ -272,7 +272,7 @@ impl UUri {
 
 == Pattern Matching
 
-[.specitem,oft-sid="dsn~uri-pattern-matching~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~uri-pattern-matching~2",oft-needs="impl,utest"]
 --
 A UUri can be used to define a _pattern_ that other UUris can then be matched against.
 For that purpose, a UUri


### PR DESCRIPTION
The revision number of the specification item for the Pattern Matching
requirements has been increased to reflect the semantic change to
the service instance ID wildcard value.

This addresses #217