### PR TITLE
Use Zenoh for L1 Transport Only

### DIFF
--- a/up-l1/zenoh.adoc
+++ b/up-l1/zenoh.adoc
@@ -65,18 +65,8 @@ Now the version is always 0x01.
 
 ==== Message Type
 
-There are 4 kinds of message types in uProtocol (publish, notification, request, response).
-Different message types **MUST** use different Zenoh API.
+There are 4 kinds of message types in uProtocol (publish, notification, request, response), all of said messages are sent using the zenoh `put()` API meaning we shall use the pub/sub infrastructure only of zenoh and not the queryable APIs.
 
-[cols="1,1"]
-|===
-| uProtocol message type | Zenoh API
-
-| publish | put
-| notification | put
-| request | get (query)
-| response | reply (queryable)
-|===
 
 ==== Priority Mapping (uProtocol to Zenoh):
 
@@ -93,9 +83,6 @@ Different message types **MUST** use different Zenoh API.
 | CS6 | REAL_TIME
 |===
 
-==== TTL
-
-While sending Request messages, TTL **MUST** be mapped to the timeout configuration in Zenoh query.
 
 === Payload
 


### PR DESCRIPTION
Zenoh is a technology that supports uProtocol L1 and L2 functionality however we have sandwiched it into the L1 uTransport interface and then expected it to be optimized and do some L2 stuff below L1 (see the confusion). The following change will state that implementations will ONLY use the pub/sub of zenoh such that it can simply send() and receive UMessages and we leave the L2 functionality (ex. RPC corelation) up to the uProtocol language libraries.