### PR TITLE
Add Initial name & number Registry Requirements

### DIFF
--- a/up-core-api/uprotocol/core/ustreamer/v1/ustreamer.proto
+++ b/up-core-api/uprotocol/core/ustreamer/v1/ustreamer.proto
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ * 
+ * This program and the accompanying materials are made available under
+ * the terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-License-Identifier: Apache-2.0
+ */
+syntax = "proto3";
+
+package uprotocol.core.ustreamer.v1;
+
+import "uprotocol/uoptions.proto";
+
+option java_package = "org.eclipse.uprotocol.core.ustreamer.v1";
+option java_outer_classname = "UStreamerProto";
+option java_multiple_files = true;
+
+// Enables generation of generic service attributes in C++
+option cc_generic_services = true;
+
+// uStreamer Service
+service uTwin {
+  option (uprotocol.service_name) = "core.ustreamer"; // Service name
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 4;
+}

--- a/up-core-api/uprotocol/core/utwin/v2/utwin.proto
+++ b/up-core-api/uprotocol/core/utwin/v2/utwin.proto
@@ -32,7 +32,7 @@ service uTwin {
   option (uprotocol.service_name) = "core.utwin"; // Service name
   option (uprotocol.service_version_major) = 2;
   option (uprotocol.service_version_minor) = 0;
-  option (uprotocol.service_id) = 26;
+  option (uprotocol.service_id) = 3;
 
   // A uE calls this API to retrieve the last uMessages for a given set of topics.<br>
   // What is returned is a list of MessageResponse with the status for message retrieval

--- a/up-l3/README.adoc
+++ b/up-l3/README.adoc
@@ -64,3 +64,35 @@ This special purpose built uEs are required to implement uProtocol and must be p
 |link:utwin/v2/README.adoc[*v2*]
 |Local cache of published events
 |===
+
+
+== Name & Number Registry
+
+In the following section we will elaborate on requirements for assigning names and numbers (ids) to uEs to avoid name space and number collisions.
+
+=== Reserved uE IDs
+
+.Reserved ue_ids
+[width="75%",cols="25%,75%",options="header",]
+|===
+|`ue_id` |Requirement
+
+| *`0x0`* | uSubscription
+| *`0x1`* | uDiscovery Client APIs
+| *`0x2`* | uDiscovery Replication APIs
+| *`0x3`* | uTwin
+| *`0x4`* | uStreamer
+| *`0x5-0xFF`* | Reserved for Eclipse-uProtocol
+| *`0x100 - 0xFFF`* | Reserved for link:https://covesa.global/project/uservices/[COVESA-uServices]
+| *`0x1000 - 0x7FFF`* | Reserved for future use
+| *`0x8000 - 0xFFFE`* | Vendor specific
+| *`0xFFFF`* | Reserved
+
+|===
+
+* uProtocol uE names and numbers *MUST* be declared in protos and added to xref:../up-core-api/uprotocol/core/README.adoc[up-core-api].
+
+=== Names
+
+ * uProtocol defined names *MUST* have `core.` prefix
+ * Vendor specific uE names *SHOULD* have the vendor name in the prefix, ex. `volvo.`, 'bmw', etc...

--- a/up-l3/README.adoc
+++ b/up-l3/README.adoc
@@ -68,24 +68,21 @@ This special purpose built uEs are required to implement uProtocol and must be p
 
 == Name & Number Registry
 
-In the following section we will elaborate on requirements for assigning names and numbers (ids) to uEs to avoid name space and number collisions.
+uProtocol URIs (UUri) contain a uEntity Identifier (`ue_id`) to refer to a particular service _type_. The `ue_id` is a 32 bit unsigned integer of which the least significant 16 bit are used to indicate the service type.
 
-=== Reserved uE IDs
+The following section defines sub-ranges of the 16 bit service type address space to be used for different purposes. This will make sure that custom service types defined in a private scope can co-exist with standard uProtocol service types without ambiguities and interference.
+
+=== uEntity ID Ranges
 
 .Reserved ue_ids
 [width="75%",cols="25%,75%",options="header",]
 |===
-|`ue_id` |Requirement
+| ID Range | Purpose
 
-| *`0x0`* | uSubscription
-| *`0x1`* | uDiscovery Client APIs
-| *`0x2`* | uDiscovery Replication APIs
-| *`0x3`* | uTwin
-| *`0x4`* | uStreamer
-| *`0x5-0xFF`* | Reserved for Eclipse-uProtocol
-| *`0x100 - 0xFFF`* | Reserved for link:https://covesa.global/project/uservices/[COVESA-uServices]
-| *`0x1000 - 0x7FFF`* | Reserved for future use
-| *`0x8000 - 0xFFFE`* | Vendor specific
+| *`0x0000 - 0x00FF`* | Eclipse uProtocol services
+| *`0x0100 - 0x0FFF`* |  link:https://covesa.global/project/uservices/[COVESA uServices]
+| *`0x1000 - 0x7FFF`* | Future use
+| *`0x8000 - 0xFFFE`* | Vendor specific services
 | *`0xFFFF`* | Reserved
 
 |===


### PR DESCRIPTION
In order to ensure that there is no overlap of assignment of names and/or numbers of uEs, this commit will add in basic rules for reserving names/numbers for specific purposes.

#67