### PR TITLE
Remove ambiguity for UNSPECIFIED UPayloadFormat

### DIFF
--- a/basics/upayloadformat.adoc
+++ b/basics/upayloadformat.adoc
@@ -28,7 +28,7 @@ The following table provides an overview of the payload formats supported by uPr
 
 | `UPAYLOAD_FORMAT_UNSPECIFIED`
 | N/A
-| Payload format was not specified so we cannot assume a format and automatically deserialize the payload, the client needs to know what payload format is,
+| The payload format is unknown. Clients will need to have gained knowledge about the concrete encoding and semantics of the payload by means of an out-of-band mechanism.
 
 
 |`UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY`

--- a/basics/upayloadformat.adoc
+++ b/basics/upayloadformat.adoc
@@ -26,6 +26,11 @@ The following table provides an overview of the payload formats supported by uPr
 |===
 |UPayloadFormat |MIME Type |Payload encoding
 
+| `UPAYLOAD_FORMAT_UNSPECIFIED`
+| N/A
+| Payload format was not specified so we cannot assume a format and automatically deserialize the payload, the client needs to know what payload format is,
+
+
 |`UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY`
 |`application/x-protobuf`
 |The message payload *MUST* be the network byte order serialization of a `google.protobuf.Any` structure that contains the payload itself along with the schema URI indicating the (protobuf) type of the payload. 

--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -124,8 +124,7 @@ enum UPriority {
 
 // The format for the data stored in the UMessage.
 enum UPayloadFormat {
-    // Payload format was not is not set,
-    // per specification, assumption is UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY
+    // Payload format was not specified.
     UPAYLOAD_FORMAT_UNSPECIFIED = 0;
 
     // Payload is an Any protobuf message that contains the packed payload

--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -124,7 +124,7 @@ enum UPriority {
 
 // The format for the data stored in the UMessage.
 enum UPayloadFormat {
-    // Payload format was not specified.
+    // Payload format is unknown.
     UPAYLOAD_FORMAT_UNSPECIFIED = 0;
 
     // Payload is an Any protobuf message that contains the packed payload


### PR DESCRIPTION
Previously (version 1.3.6 and earlier of the specification) we did not have an enum for the payload format (it was a string) and sending the string was costly to the cloud even though we always knew it was WRAPPED_IN_ANY. To avoid sending the payload format we omitted the attribute and then  "assumed" that if it was not present it would be WRAPPED_IN_ANY.  Now that we have an enum defined, it is better to remove the ambiguity of this attribute and make it explicit, this means that if someone sets it to UNSPECIFIED it really means unspecified (we don't know or are not setting it to anything). Additionally, for SOME/IP there is no way to pass this attribute (UPayloadFormat) so we have to set UPayloadFormat as UNSPECIFIED and then leave it up to the client to know the format from the source.

#237