### PR TITLE
Fix uStreamer service name

### DIFF
--- a/up-core-api/uprotocol/core/ustreamer/v1/ustreamer.proto
+++ b/up-core-api/uprotocol/core/ustreamer/v1/ustreamer.proto
@@ -25,7 +25,7 @@ option java_multiple_files = true;
 option cc_generic_services = true;
 
 // uStreamer Service
-service uTwin {
+service uStreamer {
   option (uprotocol.service_name) = "core.ustreamer"; // Service name
   option (uprotocol.service_version_major) = 1;
   option (uprotocol.service_version_minor) = 0;


### PR DESCRIPTION
When I created the ustreamer proto, I used the utwin proto and forgot to replace the service name to the correct one, this could cause issues in built artifacts.

#249