### PR TITLE
Add tags to OFT specification items

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,21 +27,39 @@ uProtocol is a communication protocol that enables software (uEs) to easily comm
 
 To achieve the above mentioned objectives, we have split the specifications into sections (folders) that are:
 
- * link:basics/README.adoc[*The Basics:*] Foundational principles and concepts of uProtocol (ex. such as addressing, IDs, message header definitions, etc...). 
+ * xref:basics/README.adoc[*The Basics:*] Foundational principles and concepts of uProtocol (ex. such as addressing, IDs, message header definitions, etc...). 
 
- * link:up-l1/README.adoc[*Transport layer (uP-L1):*] Common interface for sending and receiving of messages intended to be implemented employing a particular communication middleware technology (ex. MQTT, SOME/IP, HTTP, Zenoh, etc...).
+ * xref:up-l1/README.adoc[*Transport layer (uP-L1):*] Common interface for sending and receiving of messages intended to be implemented employing a particular communication middleware technology (ex. MQTT, SOME/IP, HTTP, Zenoh, etc...).
 
- * link:up-l2/[*Communication Layer (uP-L2):*] The common transport agnostic, programming language specific, API for the publisher/subscriber, notification, and RPC messaging patterns used by application/service developers to communicate with each other.
+ * xref:up-l2/README.adoc[*Communication Layer (uP-L2):*] The common transport agnostic, programming language specific, API for the publisher/subscriber, notification, and RPC messaging patterns used by application/service developers to communicate with each other.
 
-* link:up-l3/[*Application Layer (uP-L3):*] Service contracts for subscription management, service/device discovery, and event caching that is common across all deployments (implementations) of uProtocol.
+* xref:up-l3/README.adoc[*Application Layer (uP-L3):*] Service contracts for subscription management, service/device discovery, and event caching that is common across all deployments (implementations) of uProtocol.
 
 
 == How to get started?
 
-It is always best to start with link:basics/README.adoc[_the basics_] to familiarize yourself with common terminology used with uProtocol. 
+It is always best to start with xref:basics/README.adoc[_the basics_] to familiarize yourself with common terminology used with uProtocol. 
 
-If you're a developer who would like to use uProtocol in your application or service, please refer to the appropriate language library (ex. up-cpp, up-java, up-rust, etc..) `README.adoc`. 
+If you're a developer who would like to use uProtocol in your application or service, please refer to the appropriate language library's (ex. up-cpp, up-java, up-rust, etc..) `README.adoc`.
 
-If you would like to contribute to uProtocol to develop a new language library or transport implementation, please checkout the link:CONTRIBUTING.adoc[CONTRIBUTING.adoc].
+If you would like to contribute to uProtocol to develop a new language library or transport implementation, please checkout the xref:CONTRIBUTING.adoc[CONTRIBUTING.adoc].
 
+== Tracing Requirements
 
+Implementers of the uProtocol specification are encouraged to use link:https://github.com/itsallcode/openfasttrace[OpenFastTrace] (OFT) for making sure that they actually cover all requirements from the specification that are relevant for the implemented component.
+
+The link:https://github.com/eclipse-uprotocol/ci-cd[uProtocol CI/CD repository] contains a reusable GitHub Action workflow for link:https://github.com/eclipse-uprotocol/ci-cd/.github/workflows/trace-requirements.yaml[tracing requirements] which can be used for that purpose. The link:https://github.com/eclipse-uprotocol/up-rust[uProtocol Rust Language Library] also makes use of this workflow in its link:https://github.com/eclipse-uprotocol/up-rust/.github/workflows/nightly.yaml[nightly build] and can serve as a blueprint.
+
+The uProtocol specification documents contain a lot of requirements that are defined as OFT specification items, which cover all aspects of uProtocol. In most cases, only of a subset of these requirements will be relevant/applicable for specific components. In order to make it easier for component developers to filter out these relevant requirements, the specification items that define more specific aspects of uProtocol have been _tagged_ with corresponding labels. When running OpenFastTrace to trace the requirements, these labels can be used to filter out the relevant specification items.
+
+.OpenFastTrace Specification Item Tags
+[cols="1,3"]
+|===
+| Tag Value | Description
+
+| `CommunicationLayerImpl` | Requirements that need to be covered by concrete implementations of xref:up-l2/api.adoc[uProtocol's Communication Layer API]
+| `LanguageLibrary` | Requirements that need to be covered by xref:languages.adoc[uProtocol Language Libraries]
+| `ServiceConsumer` | Requirements that need to be covered by uEntities that invoke service operations via uProtocol
+| `ServiceProvider` | Requirements that need to be covered by uEntities that provide service operations to be invoked via uProtocol
+| `TransportLayerImpl` | Requirements that need to be covered by concrete implementations of xref:up-l1/README.adoc[uProtocol's Transport Layer API]
+|===

--- a/basics/error_model.adoc
+++ b/basics/error_model.adoc
@@ -1,5 +1,5 @@
 = uProtocol Error Model (UStatus)
-:toc:
+:toc: preamble
 :sectnums:
 
 The key words "*MUST*", "*MUST NOT*", "*REQUIRED*", "*SHALL*", "*SHALL NOT*", "*SHOULD*", "*SHOULD NOT*", "*RECOMMENDED*", "*MAY*", and "*OPTIONAL*" in this document are to be interpreted as described in https://www.rfc-editor.org/info/bcp14[IETF BCP14 (RFC2119 & RFC8174)]
@@ -18,20 +18,75 @@ SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: Apache-2.0
 ----
 
+== Overview
+
 uProtocol supports invoking operations on (remote) service providers by means of _Remote Procedure Calls_ (RPC).
 In order to do so, a client uEntity (service consumer) sends an xref:uattributes.adoc#request-attributes[RPC Request message] to the service provider and waits for a corresponding xref:uattributes.adoc#response-attributes[RPC Response message] which conveys the outcome of the invocation of the operation.
 
 In general, an RPC can succeed or fail from the service consumer's point of view. In the former case, the response message contains the data/information that is the result of successfully processing the input data conveyed in the request message. In the latter case, the response message contains details regarding the reason why processing of the request message has failed.
 
-uProtocol follows Google's https://cloud.google.com/apis/design/errors[protocol-agnostic API error model]. In particular, a service consumer *MUST* consider an RPC as _failed_ if the `commstatus` property contained in the xref:uattributes.adoc#response-attributes[response message attributes] has a value other than `OK`. In that case the response message's payload *MUST* be a serialized xref:../up-core-api/uprotocol/v1/ustatus.proto[UStatus] containing detail information about the reason for failure.
+uProtocol follows Google's https://cloud.google.com/apis/design/errors[protocol-agnostic API error model]. The following sections describe how this model is applied to uProtocol service definitions and implementations.
+
+[#data-model-definition]
+== Data Model
+
+A UStatus contains detail information about an error that has occurred while a service provider has processed an RPC Request message. The diagram below shows the UStatus class and its properties using UML2 notation.
+
+.UStatus Data Model
+[#ustatus-data-model]
+[mermaid]
+ifdef::env-github[[source,mermaid]]
+----
+classDiagram
+
+class UStatus {
+  message: String[0..1]
+  details: Object[*]
+}
+
+class UCode {
+  <<Enumeration>>
+  OK
+  CANCELLED
+  UNKNOWN
+  INVALID_ARGUMENT
+  DEADLINE_EXCEEDED
+  NOT_FOUND
+  ALREADY_EXISTS
+  PERMISSION_DENIED
+  UNAUTHENTICATED
+  RESOURCE_EXHAUSTED
+  FAILED_PRECONDITION
+  ABORTED
+  OUT_OF_RANGE
+  UNIMPLEMENTED
+  INTERNAL
+  UNAVAILABLE
+  DATA_LOSS
+}
+
+UStatus--> "0..1" UCode : code
+----
+
+Each xref:../languages.adoc[uProtocol Language Library]
+
+[.specitem,oft-sid="req~ustatus-data-model-impl~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
+--
+* *MUST* implement the <<ustatus-data-model>> using the language specific type system.
+--
+
+[.specitem,oft-sid="req~ustatus-data-model-proto~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
+--
+* *MUST* support writing and reading of an instance of the <<ustatus-data-model>> to/from a protobuf as defined in link:../up-core-api/uprotocol/v1/ustatus.proto[ustatus.proto].
+--
 
 == Service Interface Design
 
-uProtocol uses https://protobuf.dev/programming-guides/proto3/#services[Protobuf] for defining a service provider's operations. Based on the error model defined above, the _Protobuf Message_ defined/used as the response of an operation *SHOULD* only contain the data/information that represents the outcome of _successful_ execution of the operation.
+uProtocol uses https://protobuf.dev/programming-guides/proto3/#services[Protobuf] for defining a service provider's operations. In order to comply with the chosen error model, the _Protobuf Message_ defined/used as the response of an operation *SHOULD* only contain the data/information that represents the outcome of _successful_ execution of the operation.
 
-If an operation does not return any data/information on successful execution, the operation *SHOULD* use a dedicated empty response Message:
+If an operation does not return any data/information on successful execution, the operation *SHOULD* use a dedicated empty response message:
 
-[example]
+[source,proto3]
 ----
 service HvacService {
   rpc SetTemperature(SetTemperatureRequest) returns (SetTemperatureResponse);
@@ -44,16 +99,30 @@ message SetTemperatureRequest {
 message SetTemperatureResponse {}
 ----
 
-A service consumer invoking this operation will then receive a `UMessage` with an empty payload.
+A service consumer invoking this operation will then receive a `UMessage` with an empty payload if the operation has succeeded.
 
-== Service Implementation
+== Service Provider Implementation
 
-In case of _successful_ execution of a service operation, a service provider:
+[.specitem,oft-sid="dsn~service-error-model-success-response~1",oft-needs="impl,utest",oft-tags="ServiceProvider"]
+--
+In case of _successful_ execution of a service operation, a service provider
 
 * *MUST* put the operation's response Protobuf Message into the response xref:umessage.adoc[`UMessage`]'s `payload`
-* *MAY* set `commstatus` attribute (of the response message) to value `UCode.OK` to indicate successful execution. If the `commstatus` attribute is not set, it is assumed to be `UCode.OK`.
+* *MAY* set the response message's `commstatus` attribute to value `UCode.OK` to indicate successful execution. If the `commstatus` attribute is not set, it is assumed to be `UCode.OK`.
+--
 
-In case of _erroneous_ execution a service provider:
+[.specitem,oft-sid="dsn~service-error-model-error-response~1",oft-needs="impl,utest",oft-tags="ServiceProvider"]
+--
+In case of _erroneous_ execution, a service provider
 
-* *MUST* set the `commstatus` attribute of the response xref:umessage.adoc[`UMessage`] to the appropriate xref:../up-core-api/uprotocol/v1/ucode.proto[`UCode`] value indicating the failure reason. 
-* *SHOULD* populate the response xref:umessage.adoc[`UMessage`] `payload` with xref:../up-core-api/uprotocol/v1/ustatus.proto[`UStatus`] message that contains additional failure information (ex. message, details). The `UCode` from `commstatus` *MUST* be the same as that of `UStatus`.
+* *MUST* set the `commstatus` attribute of the response xref:umessage.adoc[`UMessage`] to the <<ustatus-data-model,UCode>> value other than `UCode.OK` which most closely matches the reason for failure.
+* *SHOULD* populate the response xref:umessage.adoc[`UMessage`] `payload` with a <<ustatus-data-model,UStatus>> that contains additional failure information (e.g. message, details). The `code` property value of the `UStatus` in the payload *MUST* be the same as the value of the response message's `commstatus` attribute.
+--
+
+== Service Consumer Implementation
+
+[.specitem,oft-sid="dsn~service-error-model-failed-rpc~1",oft-needs="impl,utest",oft-tags="ServiceConsumer"]
+--
+A service consumer *MUST* consider an RPC as _failed_, if the `commstatus` property contained in the xref:uattributes.adoc#response-attributes[response message attributes] has a value other than `UCode.OK`.
+In that case, the consumer *SHOULD* try to extract a <<ustatus-data-model,UStatus>> from the response message's payload and make it available to application code.
+--

--- a/languages.adoc
+++ b/languages.adoc
@@ -1,7 +1,7 @@
 = uProtocol Language Library
 :toc:
 :sectnums:
-:up-l1-ref: xref:up-l1/README.adoc[uProtocol Transport Layer interface]
+:up-l1-ref: xref:up-l1/README.adoc[uProtocol Transport Layer API]
 :up-l2-ref: xref:up-l2/README.adoc[uProtocol Communication Layer API]
 
 The key words "*MUST*", "*MUST NOT*", "*REQUIRED*", "*SHALL*", "*SHALL NOT*", "*SHOULD*", "*SHOULD NOT*", "*RECOMMENDED*", "*MAY*", and "*OPTIONAL*" in this document are to be interpreted as described in https://www.rfc-editor.org/info/bcp14[IETF BCP14 (RFC2119 & RFC8174)]
@@ -36,75 +36,60 @@ uProtocol _Transport Libraries_ are written for specific programming languages t
 
 A language library
 
-[.specitem,oft-sid="req~up-language-transport-api~1",oft-needs="impl",oft-title="Library declares Transport Layer API"]
---
-* *MUST* declare the language specific {up-l1-ref}, such that the interface can be implemented by the transport libraries.
---
-
-[.specitem,oft-sid="req~up-language-comm-api~1",oft-needs="impl",oft-title="Library declares Communication Layer API"]
---
-* *MUST* declare the language specific {up-l2-ref}, such that the interface *MAY* be implemented by the transport libraries.
---
-
-[.specitem,oft-sid="req~up-language-comm-api-default-impl~1",oft-needs="impl,utest",oft-title="Library implements Communication Layer API"]
---
-* *MUST* provide a default implementation of {up-l2-ref} based on the (abstract) Transport Layer API.
---
-
-[.specitem,oft-sid="dsn~up-language-naming~1",oft-title="Library follows naming pattern"]
+[.specitem,oft-sid="dsn~up-language-naming~1",oft-title="Library follows naming pattern",oft-tags="LanguageLibrary"]
 --
 * *MUST* be named according to pattern `up-[LANGUAGE]`, e.g. `up-rust` or `up-python`.
 --
 
-[.specitem,oft-sid="dsn~up-language-structure~1",oft-title="Library uses uProtocol namespace"]
+[.specitem,oft-sid="dsn~up-language-structure~1",oft-title="Library uses uProtocol namespace",oft-tags="LanguageLibrary"]
 --
 * *MUST* use the programming language specific namespace concept, if availabe, to indicate that the library belongs to the _uProtocol_ project. If the language supports hierarchical namespaces (like Java does), then `org.eclipse.uprotocol` *SHOULD* be used. Otherwise, a namespace of `uprotocol` *MUST* be used.
 --
 
-[.specitem,oft-sid="req~up-language-documentation~1",oft-needs="uman",oft-title="Library contains adequate README file"]
+[.specitem,oft-sid="req~up-language-documentation~1",oft-needs="uman",oft-title="Library contains adequate README file",oft-tags="LanguageLibrary"]
 --
 * *MUST* contain a `README` file that explains how to build and use the library.
---
-
-=== Test & CI
-
-A language library
-
-[.specitem,oft-sid="req~up-language-test-coverage~1",oft-title="Library has sufficient test coverage"]
---
-* *SHOULD* contain a test suite that covers 100% of all code and specifications defined in <<Content>>
---
-
-[.specitem,oft-sid="req~up-language-ci-build~1",oft-needs="impl",oft-title="CI asserts that library can be built"]
---
-* *MUST* use a CI workflow that prevents pull requests from being merged if they cannot be built.
---
-
-[.specitem,oft-sid="req~up-language-ci-test~1",oft-needs="impl",oft-title="CI asserts that test suite passes"]
---
-* *MUST* use a CI workflow that prevents pull requests from being merged if the library's test suite does not pass.
---
-
-[.specitem,oft-sid="req~up-language-ci-linter~1",oft-needs="impl",oft-title="CI asserts that code complies with linting rules"]
---
-* *MUST* use a CI workflow that prevents pull requests from being merged if the library's source code does not comply with the project's code linting rules.
---
-
-[.specitem,oft-sid="req~up-language-ci-api-docs~1",oft-needs="impl",oft-title="CI asserts that code contains API documentation"]
---
-* *MUST* use a CI workflow that prevents pull requests from being merged if the library's source code does not contain proper API documentation.
 --
 
 === Build
 
 A language library
 
-[.specitem,oft-sid="req~up-language-build-sys~1",oft-needs="impl",oft-title="Library uses common build system"]
+[.specitem,oft-sid="req~up-language-build-sys~1",oft-needs="impl",oft-title="Library uses common build system",oft-tags="LanguageLibrary"]
 --
 * *MUST* employ an existing build system that is commonly used for the given programming language.
 --
 
-[.specitem,oft-sid="req~up-language-build-deps~1",oft-needs="impl",oft-title="Library build system resolves dependencies"]
+[.specitem,oft-sid="req~up-language-build-deps~1",oft-needs="impl",oft-title="Library build system resolves dependencies",oft-tags="LanguageLibrary"]
 --
 * *MUST* resolve and include external dependencies as part of the build process only.
+--
+
+=== Test & CI
+
+A language library
+
+[.specitem,oft-sid="req~up-language-test-coverage~1",oft-title="Library has sufficient test coverage",oft-tags="LanguageLibrary,NiceToHave"]
+--
+* *SHOULD* contain a test suite that covers 100% of all code and specifications defined in <<Content>>
+--
+
+[.specitem,oft-sid="req~up-language-ci-build~1",oft-needs="impl",oft-title="CI asserts that library can be built",oft-tags="LanguageLibrary"]
+--
+* *MUST* use a CI workflow that prevents pull requests from being merged if they cannot be built.
+--
+
+[.specitem,oft-sid="req~up-language-ci-test~1",oft-needs="impl",oft-title="CI asserts that test suite passes",oft-tags="LanguageLibrary"]
+--
+* *MUST* use a CI workflow that prevents pull requests from being merged if the library's test suite does not pass.
+--
+
+[.specitem,oft-sid="req~up-language-ci-linter~1",oft-needs="impl",oft-title="CI asserts that code complies with linting rules",oft-tags="LanguageLibrary"]
+--
+* *MUST* use a CI workflow that prevents pull requests from being merged if the library's source code does not comply with the project's code linting rules.
+--
+
+[.specitem,oft-sid="req~up-language-ci-api-docs~1",oft-needs="impl",oft-title="CI asserts that code contains API documentation",oft-tags="LanguageLibrary"]
+--
+* *MUST* use a CI workflow that prevents pull requests from being merged if the library's source code does not contain proper API documentation.
 --

--- a/languages.adoc
+++ b/languages.adoc
@@ -69,11 +69,6 @@ A language library
 
 A language library
 
-[.specitem,oft-sid="req~up-language-test-coverage~1",oft-title="Library has sufficient test coverage",oft-tags="LanguageLibrary,NiceToHave"]
---
-* *SHOULD* contain a test suite that covers 100% of all code and specifications defined in <<Content>>
---
-
 [.specitem,oft-sid="req~up-language-ci-build~1",oft-needs="impl",oft-title="CI asserts that library can be built",oft-tags="LanguageLibrary"]
 --
 * *MUST* use a CI workflow that prevents pull requests from being merged if they cannot be built.
@@ -92,4 +87,9 @@ A language library
 [.specitem,oft-sid="req~up-language-ci-api-docs~1",oft-needs="impl",oft-title="CI asserts that code contains API documentation",oft-tags="LanguageLibrary"]
 --
 * *MUST* use a CI workflow that prevents pull requests from being merged if the library's source code does not contain proper API documentation.
+--
+
+[.specitem,oft-sid="req~up-language-test-coverage~1",oft-title="CI determines code coverage",oft-tags="LanguageLibrary"]
+--
+* *MUST* use a CI workflow that determines the code coverage of the test suite on a regular basis and fails if the coverage falls below a configured threshold. Implementers *SHOULD* strive for 100% coverage.
 --

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -149,7 +149,7 @@ UTransport implementations
 
 [.specitem,oft-sid="req~utransport-send-error-permission-denied~2",oft-needs="dsn,impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* fail fail invocations of <<send>> with a `UCode.PERMISSION_DENIED`, if a non-streamer client tries to send a message with a `UAttributes.source` that differs from the source address associated with the transport in anything but the _resource ID_. This is to avoid address spoofing.
+* *MUST* fail invocations of <<send>> with a `UCode.PERMISSION_DENIED`, if a non-streamer client tries to send a message with a `UAttributes.source` that differs from the source address associated with the transport in anything but the _resource ID_. This is to avoid address spoofing.
 +
 In general, an implementation of this specification will run in the same process as the client code and thus has no way of objectively asserting the client's authorities _on its own_. However, most transports will support or require clients to provide credentials for authentication as part of establishing a connection or sending messages. Most transports (like MQTT brokers or Eclipse Zenoh) will also support the definition of rules for authorizing an authenticated client. These mechanisms *MAY* then be used to implement this requirement.
 --
@@ -289,16 +289,17 @@ UTransport implementations
 +
 [#valid-source-sink-filters]
 .Valid Source/Sink Resource IDs
-[%autowidth]
+[cols="4,^1,^1"]
 |===
-| Use Case | source `resource_id` | sink `resource_id` | Publish | Notification | Request | Response
+| Use Case | source `resource_id` | sink `resource_id`
 
-| Listen for messages published to a particular topic | [8000-FFFE] |   None   |    X    |              |         |
-| Listen for notifications from a specific resource | [8000-FFFE] |     0    |         |      X       |         |
-| Listen for RPC requests to a specific operation |      0      | [1-7FFF] |         |              |    X    |
-| Listen for RPC responses from a specific operation |   [1-7FFF]  |     0    |         |              |         |    X
-| Listen for all incoming notifications and responses |     FFFF    |     0    |         |      X       |         |    X
-| Listen for all incoming notifications, RPC requests, and responses |     FFFF    |   FFFF   |         |      X       |    X    |    X
+| Listen for events published to a particular topic | [8000-FFFE] | None
+| Listen for events published to any topic | FFFF | None
+| Listen for notifications from a specific resource | [8000-FFFE] | 0
+| Listen for RPC requests to a specific operation | 0 | [1-7FFF]
+| Listen for RPC responses from a specific operation | [1-7FFF] | 0
+| Listen for all incoming notifications and responses | FFFF | 0
+| Listen for all incoming notifications, RPC requests, and responses | FFFF | FFFF
 |===
 --
 

--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -1,5 +1,5 @@
 = Transport & Session Layer (uP-L1)
-:toc:
+:toc: preamble
 :sectnums:
 
 The key words "*MUST*", "*MUST NOT*", "*REQUIRED*", "*SHALL*", "*SHALL NOT*", "*SHOULD*", "*SHOULD NOT*", "*RECOMMENDED*", "*MAY*", and "*OPTIONAL*" in this document are to be interpreted as described in https://www.rfc-editor.org/info/bcp14[IETF BCP14 (RFC2119 & RFC8174)]
@@ -18,10 +18,12 @@ SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: Apache-2.0
 ----
 
+== Overview
+
 The Transport & Session Layer is responsible for bidirectional point-2-point communication between uEntities (uE). 
 The purpose of this layer of uProtocol is to define a common API for sending and receiving messages across different transport protocols like Eclipse Zenoh, MQTT 5 or Android Binder, runtime environments like Android, Linux or MCUs, and programming languages like Java, Rust, Python or C/C++.
 
-This specification defines the transport layer's abstract API which is mapped to supported programming languages by means of uProtocol's link:../languages.adoc[language specific libraries]. The API is _implemented_ for particular transport protocols and programming languages by _uProtocol Transport Libraries_.
+This specification defines the transport layer's abstract API which is mapped to supported programming languages by means of uProtocol's xref:../languages.adoc[language specific libraries]. The API is _implemented_ for particular transport protocols and programming languages by _uProtocol Transport Libraries_.
 
 The Transport Layer API is defined using UML2 notation.
 
@@ -53,15 +55,21 @@ class LocalUriProvider {
 UTransport ..> UListener
 ----
 
-NOTE: The data types used in the following sections are defined in link:../basics/README.adoc[uProtocol Basic Types].
+NOTE: The data types used in the following sections are defined in xref:../basics/README.adoc[uProtocol Basic Types].
 
 == UListener
 
 A uEntity registers a `UListener` with the transport in order to process (incoming) messages that are of interest to the uEntity.
 
+[.specitem,oft-sid="dsn~ulistener-declaration~1",oft-needs="impl",oft-tags="LanguageLibrary"]
+--
+Each language library *MUST* declare the UListener interface using corresponding programming language specific means.
+--
+
+[#on-receive]
 === OnReceive
 
-A transport invokes this method for each newly arrived message that matches the criteria specified as part of <<register-listener,registering the listener>>.
+A <<UTransport>> implementation invokes this method for each newly arrived message that matches the criteria specified during <<register-listener,registration of the listener>>.
 
 [source]
 ----
@@ -69,12 +77,12 @@ onReceive(message: UMessage)
 ----
 
 .onReceive Parameters
-[width="100%",cols="15%,15%,70%"]
+[width="100%",cols="1,1,5"]
 |===
 |Parameter | Type | Description
 
 | message
-| link:../basics/umessage.adoc[UMessage]
+| xref:../basics/umessage.adoc[UMessage]
 | The newly received message.
 
 |===
@@ -96,6 +104,11 @@ deactivate L
 
 This is the main entry point into a transport's messaging functionality.
 
+[.specitem,oft-sid="dsn~utransport-declaration~1",oft-needs="impl",oft-tags="LanguageLibrary"]
+--
+Each language library *MUST* declare the UTransport interface using corresponding programming language specific means.
+--
+
 [#send]
 === Send
 
@@ -107,12 +120,12 @@ send(message: UMessage)
 ----
 
 .Send Parameters
-[width="100%",cols="15%,25%,60%"]
+[width="100%",cols="1,1,5"]
 |===
 |Parameter | Type | Description
 
 | message
-| link:../basics/umessage.adoc[UMessage]
+| xref:../basics/umessage.adoc[UMessage]
 | The message to send.
 |===
 
@@ -122,23 +135,30 @@ On the other hand, unsuccessful completion of this method does not necessarily m
 
 NOTE: The above strategy for retrying failed attempts to send a message results in https://www.cloudcomputingpatterns.org/at_least_once_delivery/[at-least-once delivery]. Recipient(s) of these messages should therefore be https://www.cloudcomputingpatterns.org/idempotent_processor/[Idempotent Processors].
 
-*Requirements for UTransport Implementations:*
+UTransport implementations
 
-[.specitem,oft-sid="dsn~utransport-send-preserve-data~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-send-preserve-data~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
 * *MUST* preserve all of the message's meta data and payload during transmission
 --
 
-[.specitem,oft-sid="dsn~utransport-send-error-invalid-parameter~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-send-error-invalid-parameter~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UMessage failed validation
+* *MUST* fail invocations of <<send>> with a `UCode.INVALID_ARGUMENT`, if the passed UMessage failed validation.
 --
 
-[.specitem,oft-sid="req~utransport-send-error-permission-denied~2",oft-needs="dsn"]
+[.specitem,oft-sid="req~utransport-send-error-permission-denied~2",oft-needs="dsn,impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* fail with a `UCode.PERMISSION_DENIED` if a non-streamer client tries to send a message with a `UAttributes.source` that differs from the source address associated with the transport in anything but the _resource ID_. This is to avoid address spoofing.
+* *MUST* fail fail invocations of <<send>> with a `UCode.PERMISSION_DENIED`, if a non-streamer client tries to send a message with a `UAttributes.source` that differs from the source address associated with the transport in anything but the _resource ID_. This is to avoid address spoofing.
 +
 In general, an implementation of this specification will run in the same process as the client code and thus has no way of objectively asserting the client's authorities _on its own_. However, most transports will support or require clients to provide credentials for authentication as part of establishing a connection or sending messages. Most transports (like MQTT brokers or Eclipse Zenoh) will also support the definition of rules for authorizing an authenticated client. These mechanisms *MAY* then be used to implement this requirement.
+--
+
+[.specitem,oft-sid="req~utransport-send-qos-mapping~1",oft-needs="impl,utest,uman",oft-tags="TransportLayerImpl"]
+--
+* *MUST* document if and how the implementation maps the xref:../basics/qos.adoc[UMessage Service Classes] to an existing corresponding mechanism for message prioritization of the underlying transport protocol.
++
+NOTE: An implementation *MAY* also completely ignore the service class and handle all messages equally, regardless of service class.
 --
 
 [mermaid]
@@ -169,36 +189,36 @@ receive(sourceFilter: UUri, sinkFilter: UUri [0..1]) : UMessage
 ----
 
 .Receive Parameters
-[width="100%",cols="15%,25%,60%"]
+[width="100%",cols="1,1,5"]
 |===
 |Parameter | Type | Description
 
 | sourceFilter
-| link:../basics/uri.adoc[UUri]
+| xref:../basics/uri.adoc[UUri]
 | The _source_ address pattern that messages need to match.
 
 | sinkFilter
-| link:../basics/uri.adoc[UUri]
+| xref:../basics/uri.adoc[UUri]
 | The _sink_ address pattern that messages need to match. If omitted, a message **MUST NOT** contain any sink address in order to match.
 
 | result
-| UMessage
+| xref:../basics/umessage.adoc[UMessage]
 | The least recent message that matches the given filter criteria and has not expired yet.
 
 |===
 
 This method implements the _pull_ <<delivery-method, delivery method>> on top of the underlying communication protocol.
 
-*Requirements for UTransport Implementations:*
+UTransport implementations
 
-[.specitem,oft-sid="dsn~utransport-receive-error-unimplemented~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-receive-error-unimplemented~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* return `UCode.UNIMPLEMENTED` if the transport does not support the _pull_ <<delivery-method, delivery method>>
+* *MUST* fail invocations of <<receive>> with a `UCode.UNIMPLEMENTED`, if the transport does not support the _pull_ <<delivery-method, delivery method>>.
 --
 
-[.specitem,oft-sid="dsn~utransport-receive-error-notfound~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-receive-error-notfound~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* return a `UCode.NOT_FOUND` if there are no matching messages available
+* *MUST* fail invocations of <<receive>> with a `UCode.NOT_FOUND`, if there are no matching messages available.
 --
 
 [mermaid]
@@ -232,16 +252,16 @@ registerListener(sourceFilter: UUri, sinkFilter: UUri [0..1], listener: UListene
 ----
 
 .registerListener Parameters
-[width="100%",cols="15%,15%,70%"]
+[width="100%",cols="1,1,5"]
 |===
 |Parameter | Type | Description
 
 | sourceFilter
-| link:../basics/uri.adoc[UUri]
+| xref:../basics/uri.adoc[UUri]
 | The _source_ address pattern that messages need to match.
 
 | sinkFilter
-| link:../basics/uri.adoc[UUri]
+| xref:../basics/uri.adoc[UUri]
 | The _sink_ address pattern that messages need to match. If omitted, a message must not contain any sink address in order to match.
 
 | listener
@@ -250,43 +270,61 @@ registerListener(sourceFilter: UUri, sinkFilter: UUri [0..1], listener: UListene
 |===
 
 This API is used to implement the _push_ <<delivery-method, delivery method>> on top of the underlying communication protocol.
-After this method has completed successfully, the given listener will be invoked for each message that matches the given source and sink filter patterns according to the rules defined by the link:../basics/uri.adoc[UUri specification].
 
-*Requirements for UTransport Implementations:*
+UTransport implementations
 
-[.specitem,oft-sid="dsn~utransport-registerlistener-error-unimplemented~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-registerlistener-error-unimplemented~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method, delivery method>>. In that case, the <<unregister-listener, unregisterListener>> method *MUST* also fail accordingly.
---
-
-[.specitem,oft-sid="dsn~utransport-registerlistener-error-resource-exhausted~1",oft-needs="impl,utest"]
---
-* *MUST* fail with a `UCode.RESOURCE_EXHAUSTED`, if the maximum number of listeners is reached
+* *MUST* fail invocations of <<register-listener>> with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method, delivery method>>. In that case, the <<unregister-listener, unregisterListener>> method *MUST* also fail accordingly.
 --
 
-[.specitem,oft-sid="req~utransport-registerlistener-error-invalid-parameter~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-registerlistener-error-resource-exhausted~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UUri failed validation
+* *MUST* fail invocations of <<register-listener>> with a `UCode.RESOURCE_EXHAUSTED`, if the maximum number of listeners supported by the transport has already been registered.
 --
 
-[.specitem,oft-sid="dsn~utransport-registerlistener-number-of-listeners~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-registerlistener-error-invalid-parameter~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* support registering more than one listener for any given address patterns
+* *MUST* fail invocations of <<register-listener>> with a `UCode.INVALID_ARGUMENT`, if the source and sink filter arguments' resource IDs do not match any of the entries from the table below:
++
+[#valid-source-sink-filters]
+.Valid Source/Sink Resource IDs
+[%autowidth]
+|===
+| Use Case | source `resource_id` | sink `resource_id` | Publish | Notification | Request | Response
+
+| Listen for messages published to a particular topic | [8000-FFFE] |   None   |    X    |              |         |
+| Listen for notifications from a specific resource | [8000-FFFE] |     0    |         |      X       |         |
+| Listen for RPC requests to a specific operation |      0      | [1-7FFF] |         |              |    X    |
+| Listen for RPC responses from a specific operation |   [1-7FFF]  |     0    |         |              |         |    X
+| Listen for all incoming notifications and responses |     FFFF    |     0    |         |      X       |         |    X
+| Listen for all incoming notifications, RPC requests, and responses |     FFFF    |   FFFF   |         |      X       |    X    |    X
+|===
+--
+
+[.specitem,oft-sid="dsn~utransport-registerlistener-number-of-listeners~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+--
+* *MUST* support registering more than one listener for any given address filter patterns
 --
   
-[.specitem,oft-sid="dsn~utransport-registerlistener-listener-reuse~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-registerlistener-listener-reuse~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* support registering the same listener for multiple address patterns
---
-
-[.specitem,oft-sid="req~utransport-registerlistener-max-listeners~1",oft-needs="uman"]
---
-* *MUST* document the maximum supported number of listeners per address pattern.
+* *MUST* support registering the same listener for multiple address filter patterns
 --
 
-[.specitem,oft-sid="dsn~utransport-registerlistener-idempotent~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="req~utransport-registerlistener-max-listeners~1",oft-needs="uman",oft-tags="TransportLayerImpl"]
 --
-* *MUST* be idempotent, multiple calls to said API with the same parameters *MUST* have the same effect as a single call.
+* *MUST* document the maximum supported number of listeners per address filter pattern.
+--
+
+[.specitem,oft-sid="dsn~utransport-registerlistener-idempotent~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+--
+* *MUST* make sure that multiple calls to <<register-listener>> with the same parameters have the same effect as a single call.
+--
+
+[.specitem,oft-sid="dsn~utransport-registerlistener-start-invoking-listeners~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+--
+* *MUST* deliver matching messages to a successfully registered listener. This means that for each message that the transport receives _after_ <<register-listener>> has completed successfully, and which matches the listener's source and sink filter criteria according to the xref:../basics/uri.adoc#pattern-matching[UUri pattern matching rules], the transport *MUST* invoke the listener's <<on-receive>> method _at least once_.
 --
 
 
@@ -304,6 +342,8 @@ activate T
 opt error
 alt push not supported
 T--)C : error : UStatus(UCode.UNIMPLEMENTED)
+else invalid filter syntax
+T--)C : error : UStatus(UCode.INVALID_ARGUMENT)
 else max listeners exceeded
 T--)C : error : UStatus(UCode.RESOURCE_EXHAUSTED)
 else other
@@ -313,31 +353,11 @@ end
 deactivate T
 ----
 
-In RegisterListener API, we have the source and sink `UUri` in the arguments.
-However, not all the combinations of source and sink `UUri` are valid.
-
-The following table are the valid combinations, which maps to the corresponding user case.
-
-[%autowidth]
-|===
-| source `resource_id` | sink `resource_id` | Publish | Notification | Request | Response | Use Case
-
-| [8000-FFFE] |   None   |    V    |              |         |         | A uE listens for a specific published message 
-| [8000-FFFE] |     0    |         |      V       |         |         | A uE listens for a specific notification message
-|      0      | [1-7FFF] |         |              |    V    |         | A uE listens for a specific request 
-|   [1-7FFF]  |     0    |         |              |         |    V    | A uE listens for a specific response
-|     FFFF    |     0    |         |      V       |         |    V    | A uE listens for all notifications and responses 
-|     FFFF    |   FFFF   |         |      V       |    V    |    V    | uStreamer listens for all notifications, requests, and responses
-|===
-
-Note that other combinations not in the table *MUST* never be used in RegisterListener API.
-
 Sometimes it's necessary to distinguish the message types which should be listened to.
-We can get the message types by reorganizing the table above to the following one.
 
 [%autowidth]
 |===
-| Message Type | Possible resource_id combinations {src_resource_id, sink_resource_id}
+| Message Type | Possible resource ID combinations `{source resource_id, sink resource_id}`
 
 | Publish      | {[8000-FFFE], None}
 | Notification | {[8000-FFFE], 0}, {FFFF, 0}, {FFFF, FFFF}
@@ -349,7 +369,6 @@ We can get the message types by reorganizing the table above to the following on
 === UnregisterListener
 
 Clients use this method to unregister a previously registered listener.
-After this method has returned successfully, the listener will no longer be invoked for any (matching) messages.
 
 [source]
 ----
@@ -357,16 +376,16 @@ unregisterListener(sourceFilter: UUri, sinkFilter: UUri [0..1], listener: UListe
 ----
 
 .RegisterListener Parameters
-[width="100%",cols="15%,25%,60%"]
+[width="100%",cols="1,1,5"]
 |===
 |Parameter | Type | Description
 
 | sourceFilter
-| link:../basics/uri.adoc[UUri]
+| xref:../basics/uri.adoc[UUri]
 | The source address pattern that the listener had been registered for.
 
 | sinkFilter
-| link:../basics/uri.adoc[UUri]
+| xref:../basics/uri.adoc[UUri]
 | The sink address pattern that the listener had been registered for.
 
 | listener
@@ -374,19 +393,26 @@ unregisterListener(sourceFilter: UUri, sinkFilter: UUri [0..1], listener: UListe
 | The listener to be unregistered.
 |===
 
-[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-unimplemented~1",oft-needs="impl,utest"]
+UTransport implementations
+
+[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-unimplemented~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* fail with a `UCode.UNIMPLEMENTED` if the transport does not support the _push_ <<delivery-method>>. In that case, the <<register-listener>> method *MUST* also fail accordingly.
+* *MUST* fail invocations of <<unregister-listener>> with a `UCode.UNIMPLEMENTED`, if the transport does not support the _push_ <<delivery-method>>. In that case, the <<register-listener>> method *MUST* also fail accordingly.
 --
 
-[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-notfound~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-notfound~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* fail with a `UCode.NOT_FOUND`, if no such listener had been registered before
+* *MUST* fail invocations of <<unregister-listener>> with a `UCode.NOT_FOUND`, if no such listener had been registered before.
 --
 
-[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-invalid-parameter~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~utransport-unregisterlistener-error-invalid-parameter~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* fail with a `UCode.INVALID_ARGUMENT` if the passed UUri failed validation
+* *MUST* fail invocations of <<unregister-listener>> with a `UCode.INVALID_ARGUMENT`, if the source and sink filter arguments' resource IDs do not match any of entries from <<valid-source-sink-filters>>.
+--
+
+[.specitem,oft-sid="dsn~utransport-unregisterlistener-stop-invoking-listeners~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+--
+* *MUST NOT* deliver any messages to a successfully unregistered listener.
 --
 
 .Unregistering a Listener
@@ -405,6 +431,8 @@ alt push not supported
 T--)C : error : UStatus(UCode.UNIMPLEMENTED)
 else no such listener
 T--)C : error : UStatus(UCode.NOT_FOUND)
+else invalid filter syntax
+T--)C : error : UStatus(UCode.INVALID_ARGUMENT)
 else other
 T--)C : error : UStatus
 end
@@ -416,14 +444,20 @@ deactivate T
 
 A uEntity can use the `LocalUriProvider` to create URIs representing the uEntity's local resources during runtime. This information can then be used in messages to be sent to other uEntities.
 
-A `UTransport` implementation can use the `LocalUriProvider` to determine the uEntity's authority during runtime. This information can might be useful for normalizing _local_ URIs passed into the Transport Layer API methods with authority information.
+A `UTransport` implementation can use the `LocalUriProvider` to determine the uEntity's authority during runtime. This information might be useful for normalizing _local_ URIs passed into the Transport Layer API methods which do not contain an _authority name_.
+
+[.specitem,oft-sid="dsn~localuriprovider-declaration~1",oft-needs="impl",oft-tags="LanguageLibrary"]
+--
+Each language library *MUST* declare the LocalUriProvider interface using corresponding programming language specific means.
+--
 
 === GetAuthority
 
 A uEntity invokes this method to get its own authority.
 
-[.specitem,oft-sid="req~utransport-localuriprovider-getauthority~1",oft-needs="dsn"]
+[.specitem,oft-sid="dsn~localuriprovider-getauthority~1",oft-needs="impl,utest",oft-tags="LocalUriProvider"]
 --
+The value returned by an implementation *MUST* be the uEntity's (fixed) local _authority name_.
 Implementations *MAY* use any appropriate mechanism to determine the local authority during runtime, e.g. by means of a configuration file, environment variables or a central registry.
 --
 
@@ -431,13 +465,9 @@ Implementations *MAY* use any appropriate mechanism to determine the local autho
 
 A uEntity invokes this method to get the address that it expects incoming Notification or RPC Response messages to be sent to.
 
-[.specitem,oft-sid="dsn~utransport-localuriprovider-getsource-uri-segments~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~localuriprovider-getsource-uri-segments~1",oft-needs="impl,utest",oft-tags="LocalUriProvider"]
 --
-The address returned by an implementation *MUST* consist of the uEntity's (fixed) _authority_, _identifier_ and _major version_ and _resource ID_ `0x0000`.
---
-
-[.specitem,oft-sid="req~utransport-localuriprovider-getsource-runtime~1",oft-needs="dsn"]
---
+The address returned by an implementation *MUST* consist of the uEntity's (fixed) _authority_, _identifier_, _major version_ and _resource ID_ `0x0000`.
 Implementations *MAY* use any appropriate mechanism to determine these values during runtime, e.g. by means of a configuration file, environment variables or a central registry.
 --
 
@@ -445,44 +475,42 @@ Implementations *MAY* use any appropriate mechanism to determine these values du
 
 A uEntity invokes this method to get a resource specific address to publish messages to or that it expects incoming RPC Request messages to be sent to.
 
-[.specitem,oft-sid="dsn~utransport-localuriprovider-getresource~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~localuriprovider-getresource~1",oft-needs="impl,utest",oft-tags="LocalUriProvider"]
 --
-The address returned by an implementation *MUST* consist of the uEntity's (fixed) _authority_, _identifier_ and _major version_ and the passed in _resource ID_.
---
-  
-[.specitem,oft-sid="req~utransport-localuriprovider-getresource-runtime~1",oft-needs="dsn"]
---
+The address returned by an implementation *MUST* consist of the uEntity's (fixed) _authority_, _identifier_, _major version_ and the passed in _resource ID_.
 Implementations *MAY* use any appropriate mechanism to determine these values during runtime, e.g. by means of a configuration file, environment variables or a central registry.
 --
 
 [#delivery-method]
 == Message Delivery
 
-[.specitem,oft-sid="dsn~utransport-delivery-methods~1",oft-needs="impl,utest"]
+UTransport implementations
+
+[.specitem,oft-sid="dsn~utransport-delivery-methods~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-* *MUST* support at least one of _push_ or _pull_ delivery methods and *MAY* support both
+* *MUST* support at least one of _push_ or _pull_ delivery methods and *MAY* support both.
 --
   
-[.specitem,oft-sid="req~utransport-delivery-methods-docs~1",oft-needs="uman"]
+[.specitem,oft-sid="req~utransport-delivery-methods-docs~1",oft-needs="uman",oft-tags="TransportLayerImpl"]
 --
-* *MUST* document the delivery methods they support
+* *MUST* document the delivery methods they support.
 --
 
 
 == Communication Protocol Binding
 
-Communication protocols like MQTT, HTTP define a specific Protocol Data Unit (PDU) for conveying control information and user data. A uProtocol Client implements the Transport Layer API defined above on top of such a communication protocol.
+Communication protocols like MQTT or HTTP define a specific Protocol Data Unit (PDU) for conveying control information and user data. A uProtocol Client implements the Transport Layer API defined above on top of such a communication protocol.
 
 A _communication protocol binding_ defines how the uProtocol Transport Layer API maps to the communication protocol's message exchange pattern(s) and how uProtocol messages are mapped to the protocol's PDU. Many communication protocols distinguish between a message's metadata and the (raw) payload. This is often reflected by the structure of the protocol's PDU. For example, HTTP supports _header_ fields and a _body_ which can be used to convey a uProtocol message's attributes and payload respectively.
 
 uProtocol defines bindings to the following communication protocols:
 
-* link:binder.adoc[*Android Binder*]
-* link:zenoh.adoc[*Eclipse Zenoh*]
-* link:ecal.adoc[*Eclipse ECAL*]
-* link:p3comm.adoc[*Eclipse P3Comm*]
-* link:mqtt_5.adoc[*MQTT*]
-* link:http.adoc[*HTTP*]
-* link:someip.adoc[*SOME/IP*]
+* xref:binder.adoc[*Android Binder*]
+* xref:zenoh.adoc[*Eclipse Zenoh*]
+* xref:ecal.adoc[*Eclipse ECAL*]
+* xref:p3comm.adoc[*Eclipse P3Comm*]
+* xref:mqtt_5.adoc[*MQTT 5*]
+* xref:http.adoc[*HTTP*]
+* xref:someip.adoc[*SOME/IP*]
 
 

--- a/up-l2/README.adoc
+++ b/up-l2/README.adoc
@@ -1,5 +1,4 @@
 = Communication Layer (uP-L2)
-:toc:
 :sectnums:
 
 The key words "*MUST*", "*MUST NOT*", "*REQUIRED*", "*SHALL*", "*SHALL NOT*", "*SHOULD*", "*SHOULD NOT*", "*RECOMMENDED*", "*MAY*", and "*OPTIONAL*" in this document are to be interpreted as described in https://www.rfc-editor.org/info/bcp14[IETF BCP14 (RFC2119 & RFC8174)]
@@ -18,17 +17,19 @@ SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: Apache-2.0
 ----
 
-uProtocol Communication layer (uP-L2) defines the message patterns (pub/sub, notification, and RPC) APIs used by applications & services (uEs), as well as the routing and dispatching rules for transmitting said communication messages across distributed heterogeneous systems. 
+== Overview
+
+The uProtocol Communication Layer (uP-L2) defines the message patterns (pub/sub, notification, and RPC) and APIs used by uEntities (applications & services), as well as the routing and dispatching rules for transferring messages across distributed heterogeneous systems. 
 
 .uP-L2 Sections
-[width="80%",cols="30%,70%",options="header"]
+[cols="1,4"]
 |===
 |Section | Description
 
-| link:dispatchers/README.adoc[*Dispatchers*]
-| uEs that are responsible for dispatching/forwarding messages between uEs and between uDevices.
-
-| link:api.adoc[*APIs*]
+| xref:api.adoc[*APIs*]
 |  Communication Layer API that allows uEntity developers (applications and/or services) to employ the pub/sub, notification and RPC messaging patterns.
+
+| xref:dispatchers/README.adoc[*Dispatchers*]
+| Dedicated components that are responsible for dispatching/forwarding messages between uprotocol Entities and Devices.
 
 |===

--- a/up-l2/api.adoc
+++ b/up-l2/api.adoc
@@ -1,5 +1,5 @@
 = Communication Layer APIs
-:toc:
+:toc: preamble
 :sectnums:
 
 The key words "*MUST*", "*MUST NOT*", "*REQUIRED*", "*SHALL*", "*SHALL NOT*", "*SHOULD*", "*SHOULD NOT*", "*RECOMMENDED*", "*MAY*", and "*OPTIONAL*" in this document are to be interpreted as described in https://www.rfc-editor.org/info/bcp14[IETF BCP14 (RFC2119 & RFC8174)]
@@ -20,12 +20,12 @@ SPDX-License-Identifier: Apache-2.0
 
 == Overview
 
-The Communication Layer APIs provide the common language specific interfaces for the pub/sub, notification, and RPC patterns supported by uProtocol implementations. The interfaces are declared in the link:../languages.adoc[language-specific uProtocol libraries] and as such are merely described at a high level in this document to allow the language-specific libraries to declare the interface signatures using appropriate programming language constructs.
+The Communication Layer APIs provide the common language specific interfaces for the pub/sub, notification, and RPC patterns supported by uProtocol implementations. The interfaces are declared in the xref:../languages.adoc[language-specific uProtocol libraries] and as such are merely described at a high level in this document to allow the language-specific libraries to declare the interface signatures using appropriate programming language constructs.
 
 == Interfaces
 
 .Communication Layer Interfaces
-[#messaging-apis, cols="1,1,3",options="header"]
+[#messaging-apis, cols="1,1,3"]
 |===
 |Messaging Pattern | Interface Name | Purpose
 
@@ -60,16 +60,36 @@ a| Register & unregister notification Listeners.
 
 |===
 
-* link:../languages.adoc[language-specific uProtocol libraries (Language Libraries)] *MUST* declare the Communication Layer APIs.
+Implementations of the <<messaging-apis>>
 
-*  Language Libraries *MUST* package (group) the <<messaging-apis>> into a folder (package/namespace) called `communication`.
+[.specitem,oft-sid="dsn~communication-layer-impl-async~1",oft-needs="impl,utest",oft-tags="CommunicationLayerImpl"]
+--
+* *MUST* be non-blocking and *SHOULD* be asynchronous.
+--
 
-* Language Libraries *MUST* provide a _default_ implementation of the <<messaging-apis>> based on the link:../up-l1/README.adoc[Transport Level APIs].
+[.specitem,oft-sid="dsn~communication-layer-impl-error-handling~1",oft-needs="impl,utest",oft-tags="CommunicationLayerImpl"]
+--
+* *MUST* adhere to the xref:../basics/error_model.adoc[uProtocol Error Model] for error handling for the respective APIs.
+--
 
-* *MUST* follow the link:../basics/error_model.adoc[uProtocol Error Model] for error handling for the respective APIs.
+* *MAY* use _Exceptions_ or other language-specific error handling mechanisms to indicate an erroneous outcome of a method invocation.
 
-* The API *MUST* be non-blocking and *SHOULD* be asynchronous. 
 
-* *MAY* use Exceptions or other language-specific error handling mechanisms to report errors vs returning successfully.
+Each xref:../languages.adoc[language-specific uProtocol library (Language Library)]
 
-NOTE: For more details of the language specific communication APIs, please consult your respective language-specific uProtocol library documentation.
+[.specitem,oft-sid="dsn~communication-layer-api-declaration~1",oft-needs="impl",oft-tags="LanguageLibrary"]
+--
+* *MUST* declare the <<messaging-apis>> using corresponding programming language specific means.
+--
+
+[.specitem,oft-sid="dsn~communication-layer-api-namespace~1",oft-needs="impl",oft-tags="LanguageLibrary"]
+--
+* *MUST* package (group) the <<messaging-apis>> into a folder (package/namespace) called `communication`.
+--
+
+[.specitem,oft-sid="dsn~communication-layer-impl-default~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
+--
+* *MUST* provide a _default_ implementation of the <<messaging-apis>> based on the (abstract) xref:../up-l1/README.adoc[Transport Level API].
+--
+
+NOTE: Additional information regarding implementation can be found in the respective language-specific uProtocol library documentation.


### PR DESCRIPTION
Some of the requirements in the Language Library, L1 and L2 specs need
to be covered by language libraries while others need to be implemented
by transport libraries.

In order to allow different components to filter out those specitems
that are relevant for them, OFT supports tags to be defined by
specification items.

The relevant tags can then be specified during the OFT trace run.

Also replaced links with xrefs, improved wording, added requirements
regarding listener invocation.