### PR TITLE
Fix specitem identifier for response priority value

### DIFF
--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -407,7 +407,7 @@ a|
 a|
 The link:qos.adoc[QoS] level that this message should be processed/delivered with. 
 
-[.specitem,oft-sid="dsn~up-attributes-response-reqid~1",oft-needs="impl,utest",oft-tags="ServiceProvider"]
+[.specitem,oft-sid="dsn~up-attributes-response-priority~1",oft-needs="impl,utest",oft-tags="ServiceProvider"]
 --
 * *MUST* be the same value as that of the corresponding request message's `priority` attribute.
 --


### PR DESCRIPTION
The specification item that defines requirements for an RPC response
message's priority attribute had been using a misleading identifier.
This has been fixed.