### PR TITLE
Add Gherkin Feature files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,3 +66,7 @@ The uProtocol specification documents contain a lot of requirements that are def
 | `TransportLayerImplPush` | Requirements that need to be covered by concrete implementations of xref:up-l1/README.adoc[uProtocol's Transport Layer API] supporting the the xref:up-l1/README.adoc#delivery-method[push message delivery] method
 
 |===
+
+=== Gherkin Feature Files
+
+The [features](features) folder contains Gherkin Features and Scenarios which can be used with test frameworks like [Cucumber](https://cucumber.io/) to assert compliance of implementations with the uProtocol specification. Not all parts of the specification are covered (yet), but we intend to add Scenario descriptions so that more and more of the requirements defined in the specification will be covered over time.

--- a/features/uuid/protobuf_serialization.feature
+++ b/features/uuid/protobuf_serialization.feature
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+#
+Feature: Efficient binary encoding of uProtocol UUIDs
+
+  Scenario Outline:
+    Developers using a uProtocol language library should be able to get the binary
+    encoding of a uProtocol UUID instance as specified by the UUID proto3 definition file.
+
+    [utest->req~uuid-proto~1]
+
+    The byte sequences representing the Protocol Buffer encodings have been created
+    using https://www.protobufpal.com/ based on the UUID proto3 definition from the
+    uProtocol specification.
+
+    Given a UUID having MSB <uuid_msb> and LSB <uuid_lsb>
+    When serializing the UUID to its protobuf wire format
+    Then the resulting byte sequence is <protobuf>
+    And the original UUID can be recreated from the protobuf wire format
+
+    Examples:
+      | uuid_msb           | uuid_lsb           | protobuf                             |
+      | 0x0000000000017000 | 0x8010101010101a1a | 090070010000000000111a1a101010101080 |

--- a/features/uuid/string_serialization.feature
+++ b/features/uuid/string_serialization.feature
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+#
+Feature: String representation of uProtocol UUIDs
+
+  Scenario Outline:
+    Developers using a uProtocol language library should be able to get the
+    string representation of a UUID instance as specified by uProtocol's UUID
+    specification.
+
+    [utest->dsn~uuid-spec~1]
+
+    Given a UUID having MSB <uuid_msb> and LSB <uuid_lsb>
+    When serializing the UUID to a hyphenated string
+    Then the resulting hyphenated string is <hyphenated_string>
+    And the original UUID can be recreated from the hyphenated string
+
+    Examples:
+      | uuid_msb           | uuid_lsb           | hyphenated_string                    |
+      | 0x0000000000017000 | 0x8010101010101a1a | 00000000-0001-7000-8010-101010101a1a |
+
+  Scenario Outline:
+    Developers using a uProtocol language library should not be able to create a UUID from a
+    hyphenated string that does not comply with uProtocol's UUID specification.
+
+    In particular, it should not be possible to create UUIDs having the wrong version
+    or variant identifier.
+
+    [utest->dsn~uuid-spec~1]
+
+    Given a UUID string representation <uuid_string>
+    When deserializing the hyphenated string to a UUID
+    Then the attempt fails
+
+    Examples:
+      | uuid_string                          | reason for failure     |
+      | 00000000-0001-0000-8000-0000000000ab | wrong version (0b0000) |
+      | 00000000-0001-1000-8000-0000000000ab | wrong version (0b0001) |
+      | 00000000-0001-2000-8000-0000000000ab | wrong version (0b0010) |
+      | 00000000-0001-3000-8000-0000000000ab | wrong version (0b0011) |
+      | 00000000-0001-4000-8000-0000000000ab | wrong version (0b0100) |
+      | 00000000-0001-5000-8000-0000000000ab | wrong version (0b0101) |
+      | 00000000-0001-6000-8000-0000000000ab | wrong version (0b0110) |
+      | 00000000-0001-8000-8000-0000000000ab | wrong version (0b1000) |
+      | 00000000-0001-9000-8000-0000000000ab | wrong version (0b1001) |
+      | 00000000-0001-a000-8000-0000000000ab | wrong version (0b1010) |
+      | 00000000-0001-b000-8000-0000000000ab | wrong version (0b1011) |
+      | 00000000-0001-c000-8000-0000000000ab | wrong version (0b1100) |
+      | 00000000-0001-d000-8000-0000000000ab | wrong version (0b1101) |
+      | 00000000-0001-e000-8000-0000000000ab | wrong version (0b1110) |
+      | 00000000-0001-f000-8000-0000000000ab | wrong version (0b1111) |
+      | 00000000-0001-7000-0000-0000000000ab | wrong variant (0b00)   |
+      | 00000000-0001-7000-4000-0000000000ab | wrong variant (0b01)   |
+      | 00000000-0001-7000-c000-0000000000ab | wrong variant (0b11)   |

--- a/features/uuri/pattern_matching.feature
+++ b/features/uuri/pattern_matching.feature
@@ -1,0 +1,57 @@
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+#
+Feature: Matching endpoint identifiers (UUri) against patterns
+
+  Scenario Outline:
+    Developers using a uProtocol language library should be able to verify that a specific
+    endpoint identifier matches a given pattern as specified by the UUri specification.
+
+   // [utest->dsn~uri-pattern-matching~2]
+
+    Given a URI string <uri>
+    When deserializing the URI to a UUri
+    Then the UUri matches pattern <pattern>
+
+    Examples:
+      | uri                         | pattern               |
+      | /1/1/A1FB                   | /1/1/A1FB             |
+      | /1/1/A1FB                   | //*/1/1/A1FB          |
+      | //vcu.my_vin/1/1/A1FB       | //vcu.my_vin/1/1/A1FB |
+      | /1/1/A1FB                   | //*/1/1/A1FB          |
+      | //vcu.my_vin/1/1/A1FB       | //*/FFFF/1/A1FB       |
+      | /1/1/A1FB                   | //*/FFFFFFFF/1/A1FB   |
+      | //vcu.my_vin/1/1/A1FB       | //*/FFFFFFFF/FF/A1FB  |
+      | /1/1/A1FB                   | //*/FFFFFFFF/FF/FFFF  |
+      | //vcu.my_vin/10A0101/3/A1FB | //*/FFFFFFFF/3/A1FB   |
+
+  Scenario Outline:
+    Developers using a uProtocol language library should be able to verify that a specific
+    endpoint identifier does not match a given pattern as specified by the UUri specification.
+
+    // [utest->dsn~uri-pattern-matching~2]
+
+    Given a URI string <uri>
+    When deserializing the URI to a UUri
+    Then the UUri does not match pattern <pattern>
+
+    Examples:
+      | uri                   | pattern               |
+      | /1/1/A1FB             | //mcu1/1/1/A1FB       |
+      | //vcu.my_vin/1/1/A1FB | //VCU.my_vin/1/1/A1FB |
+      | //vcu.my_vin/1/1/A1FB | //mcu1/1/1/A1FB       |
+      | /B1A5/1/A1FB          | /25B1/1/A1FB          |
+      | /B1A5/1/A1FB          | /2B1A5/1/A1FB         |
+      | /10B1A5/1/A1FB        | /40B1A5/1/A1FB        |
+      | /B1A5/1/A1FB          | /B1A5/4/A1FB          |
+      | /B1A5/1/A1FB          | /B1A5/1/90FB          |

--- a/features/uuri/protobuf_serialization.feature
+++ b/features/uuri/protobuf_serialization.feature
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+#
+Feature: Efficient binary encoding of endpoint identifiers (UUri)
+
+  Scenario Outline:
+    Developers using a uProtocol language library should be able to get the binary
+    encoding of a UUri instance as specified by the UUri proto3 definition file.
+
+    // [utest->req~uri-data-model-proto~1]
+
+    The byte sequences representing the Protocol Buffer encodings have been created
+    using https://www.protobufpal.com/ based on the UUri proto3 definition from the
+    uProtocol specification.
+
+    Given a UUri having authority <authority_name>
+    And having entity identifier <entity_id>
+    And having major version <version>
+    And having resource identifier <resource_id>
+    When serializing the UUri to its protobuf wire format
+    Then the resulting byte sequence is <protobuf>
+    And the original UUri can be recreated from the protobuf wire format
+
+    Examples:
+      | authority_name | entity_id  | version | resource_id | protobuf                                         |
+      | ""             | 0x00000001 |    0x01 |      0xa1fb |                                 1001180120fbc302 |
+      | "my_vin"       | 0x10000001 |    0x02 |      0x001a |             0a066d795f76696e1081808080011802201a |
+      | "*"            | 0x00000101 |    0xa0 |      0xa1fb |                       0a012a10810218a00120fbc302 |
+      | "mcu1"         | 0x0000FFFF |    0x01 |      0xa1fb |                 0a046d63753110ffff03180120fbc302 |
+      | "vcu.my_vin"   | 0x01a40101 |    0x01 |      0x8000 |   0a0a7663752e6d795f76696e108182900d180120808002 |
+      | "vcu.my_vin"   | 0xFFFF0101 |    0x01 |      0xa1fb | 0a0a7663752e6d795f76696e108182fcff0f180120fbc302 |
+      | "vcu.my_vin"   | 0xFFFFFFFF |    0x01 |      0xa1fb | 0a0a7663752e6d795f76696e10ffffffff0f180120fbc302 |
+      | "vcu.my_vin"   | 0x00000101 |    0x00 |      0xa1fb |           0a0a7663752e6d795f76696e10810220fbc302 |
+      | "vcu.my_vin"   | 0x00000101 |    0xFF |      0xa1fb |     0a0a7663752e6d795f76696e10810218ff0120fbc302 |
+      | "vcu.my_vin"   | 0x00000101 |    0x01 |      0x0000 |               0a0a7663752e6d795f76696e1081021801 |
+      | "vcu.my_vin"   | 0x00000101 |    0x01 |      0xFFFF |       0a0a7663752e6d795f76696e108102180120ffff03 |

--- a/features/uuri/uri_serialization.feature
+++ b/features/uuri/uri_serialization.feature
@@ -1,0 +1,85 @@
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+#
+Feature: String representation of endpoint identfiers (UUri)
+
+  Scenario Outline:
+    Developers using a uProtocol language library should be able to get the URI
+    string representation of a UUri instance as specified by the UUri specification.
+
+    // [utest->req~uri-serialization~1]
+    // [utest->dsn~uri-scheme~1]
+    // [utest->dsn~uri-host-only~2]
+    // [utest->dsn~uri-authority-mapping~1]
+    // [utest->dsn~uri-path-mapping~1]
+
+    Given a UUri having authority <authority_name>
+    And having entity identifier <entity_id>
+    And having major version <version>
+    And having resource identifier <resource_id>
+    When serializing the UUri to a URI
+    Then the resulting URI string is <uri_string>
+    And the original UUri can be recreated from the URI string
+
+    Examples:
+      | authority_name | entity_id  | version | resource_id | uri_string                      |
+      | ""             | 0x00000001 |    0x01 |      0xa1fb | up:/1/1/A1FB                    |
+      | "my_vin"       | 0x10000001 |    0x02 |      0x001a | up://my_vin/10000001/2/1A       |
+      | "*"            | 0x00000101 |    0xa0 |      0xa1fb | up://*/101/A0/A1FB              |
+      | "mcu1"         | 0x0000FFFF |    0x01 |      0xa1fb | up://mcu1/FFFF/1/A1FB           |
+      | "vcu.my_vin"   | 0x01a40101 |    0x01 |      0x8000 | up://vcu.my_vin/1A40101/1/8000  |
+      | "vcu.my_vin"   | 0xFFFF0101 |    0x01 |      0xa1fb | up://vcu.my_vin/FFFF0101/1/A1FB |
+      | "vcu.my_vin"   | 0xFFFFFFFF |    0x01 |      0xa1fb | up://vcu.my_vin/FFFFFFFF/1/A1FB |
+      | "vcu.my_vin"   | 0x00000101 |    0x00 |      0xa1fb | up://vcu.my_vin/101/0/A1FB      |
+      | "vcu.my_vin"   | 0x00000101 |    0xFF |      0xa1fb | up://vcu.my_vin/101/FF/A1FB     |
+      | "vcu.my_vin"   | 0x00000101 |    0x01 |      0x0000 | up://vcu.my_vin/101/1/0         |
+      | "vcu.my_vin"   | 0x00000101 |    0x01 |      0xFFFF | up://vcu.my_vin/101/1/FFFF      |
+
+  Scenario Outline:
+    Developers using a uProtocol language library should not be able to create a UUri from a
+    URI string that does not comply with the UUri specification.
+
+    // [utest->req~uri-serialization~1]
+    // [utest->dsn~uri-scheme~1]
+    // [utest->dsn~uri-host-only~2]
+    // [utest->dsn~uri-authority-mapping~1]
+    // [utest->dsn~uri-path-mapping~1]
+
+    Given a URI string <uri_string>
+    When deserializing the URI to a UUri
+    Then the attempt fails
+
+    Examples:
+      | uri_string                          | reason for failure                     |
+      | ""                                  | not a URI                              |
+      | "/"                                 | not a URI                              |
+      | "//"                                | not a URI                              |
+      | "up:/"                              | not a URI                              |
+      | "up://"                             | not a URI                              |
+      | xy://vcu.my_vin/101/1/A1FB          | unsupported schema                     |
+      | up://""/101/1/A1FB                  | authority name with reserved character |
+      | up://vcu#my-vin/101/1/A1FB          | authority name with reserved character |
+      | up://vcu%my-vin/101/1/A1FB          | authority name with reserved character |
+      | ////1/A1FB                          | missing authority and entity           |
+      | /////A1FB                           | missing authority, entity and version  |
+      | up://vcu.my_vin/101/1/A1FB?foo=bar  | URI with query                         |
+      | up://vcu.my_vin/101/1/A1FB#foo      | URI with fragment                      |
+      | up://vcu.my_vin:1516/101/1/A1FB     | authority with port                    |
+      | up://user:pwd@vcu.my_vin/101/1/A1FB | authority with user info               |
+      | up://"vcu.my-vin"/0/1/A1FB          | invalid entity ID                      |
+      | up:/1G1/1/A1FB                      | non-hex entity ID                      |
+      | up:/123456789/1/A1FB                | entity ID exceeds max length           |
+      | up:/101/G/A1FB                      | non-hex version                        |
+      | /101/123/A1FB                       | version exceeds max length             |
+      | /101/1/G1FB                         | non-hex resource ID                    |
+      | /101/1/12345                        | resource ID exceeds max length         |


### PR DESCRIPTION
The Feature files are supposed to serve as "test vectors" for
asserting compliance with (aspects of) the specification.

Addresses https://github.com/eclipse-uprotocol/up-tck/issues/116