### PR TITLE
Remove subscriber/subscription list pagination

### DIFF
--- a/up-core-api/uprotocol/core/usubscription/v3/usubscription.proto
+++ b/up-core-api/uprotocol/core/usubscription/v3/usubscription.proto
@@ -215,23 +215,21 @@ message UnsubscribeResponse {}
 // Passed to FetchSubscribers such that we can obtain a list of subscribers to
 // a particular topic
 message FetchSubscribersRequest {
+  reserved 2;
+
   // Topic we wish to find the subscribers for
   uprotocol.v1.UUri topic = 1;
-
-  // Offset in the fetch requests
-  optional uint32 offset = 2;
 }
 
 
 // Returned from FetchSubscribers(), this message contains a repeated list of
 // SubscriberInfo
 message FetchSubscribersResponse {
-  reserved 3;
+  reserved 2, 3;
   // List of subscribers
   repeated SubscriberInfo subscribers = 1;
 
   // Set to true if the batch did not return all records
-  optional bool has_more_records = 2;
 }
 
 
@@ -257,6 +255,8 @@ message Subscription {
 
 
 message FetchSubscriptionsRequest {
+  reserved 3;
+
   oneof request {
     // Topic to register/unregister to receive subscription change notifications
     uprotocol.v1.UUri topic = 1;
@@ -264,19 +264,15 @@ message FetchSubscriptionsRequest {
     // Subscribers's information
     SubscriberInfo subscriber = 2;
   }
-
-  // Offset in the fetch requests
-  optional uint32 offset = 3;
 }
 
 
 // Results from FetchSubscriptions() API
 message FetchSubscriptionsResponse {
+  reserved 2;
+
   // Repeated list of subscriptions for a subscriber
   repeated Subscription subscriptions = 1;
-
-  // Set to true if the batch did not return all records
-  optional bool has_more_records = 2;
 }
 
 

--- a/up-l3/usubscription/v3/README.adoc
+++ b/up-l3/usubscription/v3/README.adoc
@@ -227,21 +227,6 @@ When receiving a `FetchSubscribers()` request that contains a topic that
 a uSubscription service *MUST* return a failure status message with link:../../../up-core-api/uprotocol/v1/ucode.proto[`UCode`] `INVALID_ARGUMENT`.
 ****
 
-[.specitem,oft-sid="req~usubscription-fetch-subscribers-stable-sorting~1",oft-needs="impl,utest"]
-****
-Subscriber entries returned by subsequent calls to the `FetchSubscribers()` function *MUST* be in identical order.
-****
-
-[.specitem,oft-sid="req~usubscription-fetch-subscribers-has-more-records~1",oft-needs="impl,utest"]
-****
-If the list of subscribers returned in response to a `FetchSubscribers()` call does not contain all existing subscription relationships, uSubscription service *MUST* set the `has_more_records` field of the `FetchSubscribersResponse` to `true`.
-****
-
-[.specitem,oft-sid="req~usubscription-fetch-subscribers-offset~1",oft-needs="impl,utest"]
-****
-When a client calls the `FetchSubscribers()` function with an `offset` argument, the list of subscribers returned by uSubscription service *MUST* omit all subscriber entries up to the provided offset.
-****
-
 [#fetch-subscriptions-operation]
 === FetchSubscriptions()
 
@@ -281,21 +266,6 @@ When receiving a `FetchSubscriptions()` request that contains a subscriber URI t
 * contains a _wildcard_ resource ID,
 
 a uSubscription service *MUST* return a failure status message with link:../../../up-core-api/uprotocol/v1/ucode.proto[`UCode`] `INVALID_ARGUMENT`.
-****
-
-[.specitem,oft-sid="req~usubscription-fetch-subscriptions-has-more-records~1",oft-needs="impl,utest"]
-****
-If the list of subscriptions returned in response to a `FetchSubscriptions()` call does not contain all existing subscription relationships, uSubscription service *MUST* set the `has_more_records` field of the `FetchSubscriptionsResponse` to `true`.
-****
-
-[.specitem,oft-sid="req~usubscription-fetch-subscriptions-stable-sorting~1",oft-needs="impl,utest"]
-****
-Subscription entries returned by subsequent calls to the `FetchSubscriptions()` function *MUST* be in identical order.
-****
-
-[.specitem,oft-sid="req~usubscription-fetch-subscriptions-offset~1",oft-needs="impl,utest"]
-****
-When a client calls the `FetchSubscriptions()` function with an `offset` argument, the list of subscriptions returned by uSubscription service *MUST* omit all subscription relationship entries up to the provided offset.
 ****
 
 [#usubscription-topic]


### PR DESCRIPTION
uSubscription: as per discussion in #282, this PR removes protobuf attributes and requirements associated with the pagination of lists returned by getSubscribers/getSubscriptions.

I've not taken the detour of deprecating these attributes first - as we're not in production for now, I'm thinking we can directly remove&reserve these properties.