### PR TITLE
Cover UTransport requirements by default

### DIFF
--- a/up-l1/README.adoc
+++ b/up-l1/README.adoc
@@ -137,7 +137,7 @@ NOTE: The above strategy for retrying failed attempts to send a message results 
 
 UTransport implementations
 
-[.specitem,oft-sid="dsn~utransport-send-preserve-data~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+[.specitem,oft-sid="req~utransport-send-preserve-data~1",oft-needs="dsn",oft-tags="TransportLayerImpl"]
 --
 * *MUST* preserve all of the message's meta data and payload during transmission
 --

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -36,7 +36,7 @@ A uProtocol message consists of _UAttributes_ and optional payload. The followin
 
 === UAttributes
 
-[.specitem,oft-sid="dsn~up-transport-mqtt5-attributes-mapping~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+[.specitem,oft-sid="dsn~up-transport-mqtt5-attributes-mapping~1",oft-covers="req~utransport-send-preserve-data~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
 An MQTT 5 PUBLISH packet that is used to convey a uProtocol message *MUST* contain properties as defined in <<uAttributes Mapping to MQTT 5 PUBLISH Properties>> for those and only those of the UMessage's attributes which have a non-empty value.
 --
@@ -82,7 +82,7 @@ a| The destination (address) of the message
 
 | _priority_
 | User Property [key: _5_]
-a| The message's priority as defined in link:../basics/qos.adoc[QoS doc]
+a| The message's service class as defined in link:../basics/qos.adoc[QoS doc]
 
 * *MUST* be set to the value of the _uprotocol.ce_name_ option defined for the
 link:../up-core-api/uprotocol/uattributes.proto[UPriority enum].
@@ -146,7 +146,7 @@ Note that the enum's integer value is used instead of the _uprotocol.mime_type_ 
 
 === Payload
 
-[.specitem,oft-sid="dsn~up-transport-mqtt5-payload-mapping~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+[.specitem,oft-sid="dsn~up-transport-mqtt5-payload-mapping~1",oft-covers="req~utransport-send-preserve-data~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
 An MQTT 5 PUBLISH packet that is used to convey a uProtocol message *MUST* contain in its payload the unaltered value of the UMessage's _payload_ field.
 --

--- a/up-l1/zenoh.adoc
+++ b/up-l1/zenoh.adoc
@@ -37,7 +37,7 @@ A uProtocol message consists of _UAttributes_ and optional payload. The followin
 
 === UAttributes
 
-[.specitem,oft-sid="dsn~up-transport-zenoh-attributes-mapping~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+[.specitem,oft-sid="dsn~up-transport-zenoh-attributes-mapping~1",oft-covers="req~utransport-send-preserve-data~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
 The value of a Zenoh Resource that is used to convey a uProtocol message *MUST* contain _attachments_ as defined in <<uAttributes Mapping to Zenoh Attachments>>.
 --
@@ -66,13 +66,13 @@ All types of uProtocol messages *MUST* be transferred using Zenoh's pub/sub API 
 
 ==== Message Priority
 
-[.specitem,oft-sid="dsn~up-transport-zenoh-message-priority-mapping~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+[.specitem,oft-sid="dsn~up-transport-zenoh-message-priority-mapping~1",oft-covers="req~utransport-send-qos-mapping~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-The uProtocol and Zenoh message priority levels *MUST* be mapped according to the following table:
+The uProtocol service classes *MUST* be mapped to Zenoh message priority levels as follows:
 
 [cols="1,1"]
 |===
-| uProtocol Priority | Zenoh Priority
+| uProtocol Service Class | Zenoh Message Priority
 
 | `CS0` | `BACKGROUND`
 | `CS1` | `DATA_LOW`
@@ -81,12 +81,13 @@ The uProtocol and Zenoh message priority levels *MUST* be mapped according to th
 | `CS4` | `INTERACTIVE_LOW`
 | `CS5` | `INTERACTIVE_HIGH`
 | `CS6` | `REAL_TIME`
+| `UNSPECIFIED` | `DATA_LOW`
 |===
 --
 
 === Payload Mapping
 
-[.specitem,oft-sid="dsn~up-transport-zenoh-payload-mapping~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
+[.specitem,oft-sid="dsn~up-transport-zenoh-payload-mapping~1",oft-covers="req~utransport-send-preserve-data~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
 A Zenoh message that is used to convey a uProtocol message *MUST* contain in its payload the unaltered value of the UMessage's _payload_ field.
 --


### PR DESCRIPTION
The Zenoh and the MQTT 5 transport spec have been amended to cover
some generic requirements from the Transport Layer specification
by default. This relieves implementations from creating corresponding
spec items which do contain anything specific to the implementation.