### PR TITLE
Fix covered OFT specitem ID

### DIFF
--- a/basics/uuid_string_serialization.feature
+++ b/basics/uuid_string_serialization.feature
@@ -18,7 +18,7 @@ Feature: String representation of uProtocol UUIDs
     string representation of a UUID instance as specified by uProtocol's UUID
     specification.
 
-    [utest->dsn~uuid-spec~1]
+    [utest->req~uuid-hex-and-dash~1]
 
     Given a UUID having MSB <uuid_msb> and LSB <uuid_lsb>
     When serializing the UUID to a hyphenated string
@@ -36,7 +36,7 @@ Feature: String representation of uProtocol UUIDs
     In particular, it should not be possible to create UUIDs having the wrong version
     or variant identifier.
 
-    [utest->dsn~uuid-spec~1]
+    [utest->req~uuid-hex-and-dash~1]
 
     Given a UUID string representation <uuid_string>
     When deserializing the hyphenated string to a UUID


### PR DESCRIPTION
The Gherkin scenarios for verifying UUID serialization to its
hex-and-dash string representation have been adapted to refer to the
specific OFT specitem from the UUID specification document.