### PR TITLE
Fix copy-paste duplication of req id

### DIFF
--- a/up-l3/usubscription/v3/README.adoc
+++ b/up-l3/usubscription/v3/README.adoc
@@ -375,7 +375,7 @@ Subscription change notifications *MUST* use topic `SubscriptionChange` with res
 
 === Default subscriber notifications
 
-[.specitem,oft-sid="dsn~usubscription-change-notification-topic~1",oft-needs="impl,utest"]
+[.specitem,oft-sid="dsn~usubscription-change-notification-update~1",oft-needs="impl,utest"]
 ****
 If a subscriber-topic relationship changes, uSubscription service *MUST* send a corresponding `Update()` notification to the topic subscriber.
 ****


### PR DESCRIPTION
In usubscription spec, there was a copy-paste induced duplication of a requirement id - this PR fixes that.