### PR TITLE
Add behavior to reset() operation to make it more useful in practice

### DIFF
--- a/up-l3/usubscription/v3/README.adoc
+++ b/up-l3/usubscription/v3/README.adoc
@@ -467,6 +467,17 @@ The uSubscription service `Reset()` function *MUST* implement the corresponding 
 When the `Reset()` function is called, the uSubscription service *MUST* flush all stored subscription information, including any persistently stored subscriptions.
 ****
 
+[.specitem,oft-sid="req~usubscription-reset-notification~1",oft-needs="impl,utest"]
+****
+When the `Reset()` function is called, after stored subscription information is flushed, uSubscription service *MUST* notify all subscribers and uEntities that registered for change notifications about the reset, by sending a messages of type `Update` for each subscribed/registered topic, with a subscription state of `UNSUBSCRIBED`.
+****
+
+[.specitem,oft-sid="req~usubscription-reset-notification-clients~1",oft-needs="impl,utest"]
+****
+When the `Reset()` function is called, after all stored subscription information has been flushed and before `Update` notifications are sent, uSubscription service *MUST* clear the list of uEntities that have registered for subscription change notification messages (via `RegisterForNotifications()`), including any persistently stored registrations.
+****
+
+
 [.specitem,oft-sid="req~usubscription-reset-only-usubscription~1",oft-needs="impl,utest"]
 ****
 When receiving a `Reset()` call from a source that is not another uSubscription services (i.e. from source URIs where uEntity ID (`ue_id`) does not equal _0x0_), uSubscription service *MUST* return a failure status message with {ucode_link} `PERMISSION_DENIED`.


### PR DESCRIPTION
To make the uSubscription `reset()` operation more useful and usable in practice, add requirements for client-notifications on reset() and how to deal with notification-lists.