### PR TITLE
Add missing utest attribute for reset-protobuf requirement

### DIFF
--- a/up-l3/usubscription/v3/README.adoc
+++ b/up-l3/usubscription/v3/README.adoc
@@ -457,7 +457,7 @@ Subscribe (and unsubscribe) to remote topics are handled by RPC calls between uS
 
 This is a private API, to be used only between uSubscription services. Regular uEntities can call Unsubscribe() to flush their own subscriptions.
 
-[.specitem,oft-sid="dsn~usubscription-reset-protobuf~1",oft-needs="impl"]
+[.specitem,oft-sid="dsn~usubscription-reset-protobuf~1",oft-needs="impl,utest"]
 ****
 The uSubscription service `Reset()` function *MUST* implement the corresponding protobuf definition in {usubscription_proto_link}.
 ****


### PR DESCRIPTION
Fix minor oversight: `dsn~usubscription-reset-protobuf~1` should also demand a test.