### PR TITLE
Fix/Improve UURI Gherkin features

### DIFF
--- a/basics/uuri_pattern_matching.feature
+++ b/basics/uuri_pattern_matching.feature
@@ -27,13 +27,24 @@ Feature: Matching endpoint identifiers (UUri) against patterns
       | uri                         | pattern               |
       | /1/1/A1FB                   | /1/1/A1FB             |
       | /1/1/A1FB                   | //*/1/1/A1FB          |
-      | //vcu.my_vin/1/1/A1FB       | //vcu.my_vin/1/1/A1FB |
-      | /1/1/A1FB                   | //*/1/1/A1FB          |
-      | //vcu.my_vin/1/1/A1FB       | //*/FFFF/1/A1FB       |
+      | /1/1/A1FB                   | /FFFF/1/A1FB          |
+      | /1/1/A1FB                   | //*/FFFF/1/A1FB       |
+      | /1/1/A1FB                   | /FFFFFFFF/1/A1FB      |
       | /1/1/A1FB                   | //*/FFFFFFFF/1/A1FB   |
-      | //vcu.my_vin/1/1/A1FB       | //*/FFFFFFFF/FF/A1FB  |
+      | /1/1/A1FB                   | /1/FF/A1FB            |
+      | /1/1/A1FB                   | //*/1/FF/A1FB         |
+      | /1/1/A1FB                   | /1/1/FFFF             |
+      | /1/1/A1FB                   | //*/1/1/FFFF          |
+      | /1/1/A1FB                   | /FFFFFFFF/FF/FFFF     |
       | /1/1/A1FB                   | //*/FFFFFFFF/FF/FFFF  |
-      | //vcu.my_vin/10A0101/3/A1FB | //*/FFFFFFFF/3/A1FB   |
+      | /10001/1/A1FB               | /10001/1/A1FB         |
+      | /10001/1/A1FB               | //*/10001/1/A1FB      |
+      | /10001/1/A1FB               | /FFFFFFFF/1/A1FB      |
+      | /10001/1/A1FB               | //*/FFFFFFFF/1/A1FB   |
+      | /10001/1/A1FB               | /FFFFFFFF/FF/FFFF     |
+      | /10001/1/A1FB               | //*/FFFFFFFF/FF/FFFF  |
+      | //vcu.my_vin/1/1/A1FB       | //vcu.my_vin/1/1/A1FB |
+      | //vcu.my_vin/1/1/A1FB       | //*/1/1/A1FB          |
 
   Scenario Outline:
     Developers using a uProtocol language library should be able to verify that a specific
@@ -48,8 +59,11 @@ Feature: Matching endpoint identifiers (UUri) against patterns
     Examples:
       | uri                   | pattern               |
       | /1/1/A1FB             | //mcu1/1/1/A1FB       |
-      | //vcu.my_vin/1/1/A1FB | //VCU.my_vin/1/1/A1FB |
       | //vcu.my_vin/1/1/A1FB | //mcu1/1/1/A1FB       |
+      | //vcu/B1A5/1/A1FB     | //vc/FFFFFFFF/FF/FFFF |
+      | /B1A5/1/A1FB          | //*/25B1/FF/FFFF      |
+      | /B1A5/1/A1FB          | //*/FFFFFFFF/2/FFFF   |
+      | /B1A5/1/A1FB          | //*/FFFFFFFF/FF/ABCD  |
       | /B1A5/1/A1FB          | /25B1/1/A1FB          |
       | /B1A5/1/A1FB          | /2B1A5/1/A1FB         |
       | /10B1A5/1/A1FB        | /40B1A5/1/A1FB        |

--- a/basics/uuri_uri_serialization.feature
+++ b/basics/uuri_uri_serialization.feature
@@ -60,26 +60,27 @@ Feature: String representation of endpoint identfiers (UUri)
     Then the attempt fails
 
     Examples:
-      | uri_string                          | reason for failure                     |
-      | ""                                  | not a URI                              |
-      | "/"                                 | not a URI                              |
-      | "//"                                | not a URI                              |
-      | "up:/"                              | not a URI                              |
-      | "up://"                             | not a URI                              |
-      | xy://vcu.my_vin/101/1/A1FB          | unsupported schema                     |
-      | up://""/101/1/A1FB                  | authority name with reserved character |
-      | up://vcu#my-vin/101/1/A1FB          | authority name with reserved character |
-      | up://vcu%my-vin/101/1/A1FB          | authority name with reserved character |
-      | ////1/A1FB                          | missing authority and entity           |
-      | /////A1FB                           | missing authority, entity and version  |
-      | up://vcu.my_vin/101/1/A1FB?foo=bar  | URI with query                         |
-      | up://vcu.my_vin/101/1/A1FB#foo      | URI with fragment                      |
-      | up://vcu.my_vin:1516/101/1/A1FB     | authority with port                    |
-      | up://user:pwd@vcu.my_vin/101/1/A1FB | authority with user info               |
-      | up://"vcu.my-vin"/0/1/A1FB          | invalid entity ID                      |
-      | up:/1G1/1/A1FB                      | non-hex entity ID                      |
-      | up:/123456789/1/A1FB                | entity ID exceeds max length           |
-      | up:/101/G/A1FB                      | non-hex version                        |
-      | /101/123/A1FB                       | version exceeds max length             |
-      | /101/1/G1FB                         | non-hex resource ID                    |
-      | /101/1/12345                        | resource ID exceeds max length         |
+      | uri_string                            | reason for failure                                    |
+      | ""                                    | not a URI                                             |
+      | "  "                                  | not a URI                                             |
+      | "$$"                                  | not a URI                                             |
+      | "up:"                                 | not a URI                                             |
+      | "up:/"                                | not a URI                                             |
+      | "/"                                   | not a URI                                             |
+      | "//"                                  | not a URI                                             |
+      | "//vcu.my_vin"                        | just an authority                                     |
+      | "//VCU"                               | authority with uppercase characters                   |
+      | "////1/A1FB"                          | missing authority and entity                          |
+      | "/////A1FB"                           | missing authority, entity and version                 |
+      | "xy://vcu.my_vin/101/1/A"             | unsupported schema                                    |
+      | "//vcu.my_vin/101/1/A?foo=bar"        | URI with query                                        |
+      | "//vcu.my_vin/101/1/A#foo"            | URI with fragment                                     |
+      | "//vcu.my-vin:1516/101/1/A"           | server-based authority with port                      |
+      | "//user:pwd@vcu.my-vin/101/1/A"       | server-based authority with user info                 |
+      | "//reg_based:1516/101/1/A"            | registry-based authority name with invalid characters |
+      | "up://vcu.my-vin/1G1/1/A1FB"          | non-hex entity ID                                     |
+      | "/123456789/1/A1FB"                   | entity ID exceeds max length                          |
+      | "up:/101/G/A1FB"                      | non-hex version                                       |
+      | "//vcu.my-vin/101/123/A1FB"           | version exceeds max length                            |
+      | "/101/1/G1FB"                         | non-hex resource ID                                   |
+      | "up://vcu.my-vin/101/1/12345"         | resource ID exceeds max length                        |


### PR DESCRIPTION
Add unambiguous example values for server-based authorities which should
fail to be deserialized as UURIs.

Removed invalid pattern URI from scenario. Also added more example
values to increase coverage.

Fixes #300 and #302