### PR TITLE
Adapt specitem references to reflect recent changes

### DIFF
--- a/basics/uuri_uri_serialization.feature
+++ b/basics/uuri_uri_serialization.feature
@@ -21,7 +21,7 @@ Feature: String representation of endpoint identfiers (UUri)
     [utest->dsn~uri-scheme~1]
     [utest->dsn~uri-host-only~2]
     [utest->dsn~uri-authority-mapping~1]
-    [utest->dsn~uri-path-mapping~1]
+    [utest->dsn~uri-path-mapping~2]
 
     Given a UUri having authority <authority_name>
     And having entity identifier <entity_id>
@@ -53,7 +53,7 @@ Feature: String representation of endpoint identfiers (UUri)
     [utest->dsn~uri-scheme~1]
     [utest->dsn~uri-host-only~2]
     [utest->dsn~uri-authority-mapping~1]
-    [utest->dsn~uri-path-mapping~1]
+    [utest->dsn~uri-path-mapping~2]
 
     Given a URI string <uri_string>
     When deserializing the URI to a UUri


### PR DESCRIPTION
One of the specitems in the uProtocol URI spec has been updated and
assigned a new revision number.

The Gherkin scenarios in the uuri_uri_serialization.feature file
refer to the old revision number. This commit updates those references
to the new revision number to ensure that the scenarios accurately reflect
the current state of the specification.