### PR TITLE
Complete editorial overhaul of usubscription.proto

### DIFF
--- a/up-core-api/uprotocol/core/usubscription/v3/usubscription-asyncapi.yaml
+++ b/up-core-api/uprotocol/core/usubscription/v3/usubscription-asyncapi.yaml
@@ -27,8 +27,8 @@ info:
   x-uprotocol:
     # [impl->dsn~usubscription-service_name~1]
     serviceName: core.usubscription
-    # [impl->dsn~usubscription-subscribe-method_id~1]
-    serviceId: 0x0
+    # [impl->dsn~usubscription-uentity_id~1]
+    uEntityID: 0x0
 
 defaultContentType: "application/protobuf"
 

--- a/up-core-api/uprotocol/core/usubscription/v3/usubscription-asyncapi.yaml
+++ b/up-core-api/uprotocol/core/usubscription/v3/usubscription-asyncapi.yaml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+# This program and the accompanying materials are made available under
+# the terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-FileType: SOURCE
+# SPDX-License-Identifier: Apache-2.0
+
+asyncapi: '3.0.0'
+id: urn:eclipse:org:uprotocol:usubscription
+info:
+  title: Eclipse uProtocol uSubscription service API definition
+  version: '1.0.0'
+  description: |
+    uProtocol service for managing x-system pub/sub subscriptions.
+  contact:
+    name: Daniel Krippner
+    email: daniel.Krippner@etas.com
+  license:
+    name: Apache-2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+  tags:
+    - name: uProtocol uSubscription
+  x-uprotocol:
+    # [impl->dsn~usubscription-service_name~1]
+    serviceName: core.usubscription
+    # [impl->dsn~usubscription-subscribe-method_id~1]
+    serviceId: 0x0
+
+defaultContentType: "application/protobuf"
+
+channels:
+  subscribeRequests:
+    summary: Client-topic subscription request.
+    messages:
+      protobuf:
+        contentType: 'application/protobuf'
+        payload:
+          schemaFormat: 'application/vnd.google.protobuf;version=3'
+          schema:
+            $ref: './usubscription.proto#/uprotocol.core.usubscription.v3.SubscribeRequest'
+  subscribeResponses:
+    summary: Client-topic subscription status.
+    messages:
+      protobuf:
+        contentType: 'application/protobuf'
+        payload:
+          schemaFormat: 'application/vnd.google.protobuf;version=3'
+          schema:
+            $ref: './usubscription.proto#/uprotocol.core.usubscription.v3.SubscribeResponse'
+  unsubscribeRequests:
+    summary: Client-topic unsubscribe request.
+    messages:
+      protobuf:
+        contentType: 'application/protobuf'
+        payload:
+          schemaFormat: 'application/vnd.google.protobuf;version=3'
+          schema:
+            $ref: './usubscription.proto#/uprotocol.core.usubscription.v3.UnsubscribeRequest'
+  unsubscribeResponses:
+    summary: Client-topic unsubscribe response.
+    messages:
+      protobuf:
+        contentType: 'application/protobuf'
+        payload:
+          schemaFormat: 'application/vnd.google.protobuf;version=3'
+          schema:
+            $ref: './usubscription.proto#/uprotocol.core.usubscription.v3.UnsubscribeResponse'
+
+operations:
+  Subscribe:
+    # [dsn->impl:req~usubscription-subscribe-signature~1]
+    title: Susbcribe to a topic.
+    summary: Register the calling client as subscriber to a topic.
+    tags:
+      - name: uSubscription
+        description: uProtocol uSubscription API operation.
+    externalDocs:
+      description: uSubscription specification
+      $ref: '../../../../../up-l3/usubscription/v3/README.adoc#subscribe-operation'
+    channel:
+      $ref: "#/channels/subscribeRequests"
+    action: receive
+    reply:
+      channel:
+        $ref: "#/channels/subscribeResponses"
+    bindings:
+      x-uprotocol:
+        # [impl->dsn~usubscription-subscribe-method_id~1]
+        methodId: 0x0001
+
+  Unsubscribe:
+    # [dsn->impl:req~usubscription-unsubscribe-signature~1]
+    title: Unsubscribe from a topic.
+    summary: Unregister the calling susbcriber client from a topic.
+    tags:
+      - name: uSubscription
+        description: uProtocol uSubscription API operation.
+    externalDocs:
+      description: uSubscription specification
+      $ref: '../../../../../up-l3/usubscription/v3/README.adoc#unsubscribe-operation'
+    channel:
+      $ref: "#/channels/unsubscribeRequests"
+    action: receive
+    reply:
+      channel:
+        $ref: "#/channels/unsubscribeResponses"
+    bindings:
+      x-uprotocol:
+        # [impl->dsn~usubscription-unsubscribe-method_id~1]
+        methodId: 0x0002

--- a/up-core-api/uprotocol/core/usubscription/v3/usubscription.proto
+++ b/up-core-api/uprotocol/core/usubscription/v3/usubscription.proto
@@ -11,6 +11,7 @@
  * SPDX-FileType: SOURCE
  * SPDX-License-Identifier: Apache-2.0
  */
+
 syntax = "proto3";
 
 package uprotocol.core.usubscription.v3;
@@ -24,57 +25,39 @@ option java_package = "org.eclipse.uprotocol.core.usubscription.v3";
 option java_outer_classname = "USubscriptionProto";
 option java_multiple_files = true;
 
-// Enables generation of generic service attributes in C++
+// Enable generation of generic service attributes in C++
 option cc_generic_services = true;
 
-// Subscription Service Interface definition
+// Subscription service interface definition
 service uSubscription {
-  option (uprotocol.service_name) = "core.usubscription"; // Service name
+  option (uprotocol.service_name) = "core.usubscription";
   option (uprotocol.service_version_major) = 3;
   option (uprotocol.service_version_minor) = 0;
   option (uprotocol.service_id) = 0;
 
-  // uSubscription change Notification topic that sends the Update message
+  // uSubscription change Notification topic used for Update messages
   option (uprotocol.notification_topic) = {
     id: 0x8000,
     name: "SubscriptionChange",
     message: "Update"
   };
 
-
-  // A consumer (application) calls this API to subscribe to a topic.
-  // What is passed is the SubscriptionRequest message containing the topic, the
-  // subscriber's name, and any Subscription Attributes. This API returns a
-  // SubscriptionResponse message containing the status of the request along with
-  // any event delivery configuration
-  // required to consume the event. Calling this API also registers the subscriber
-  // to received subscription change notifications if ever the subscription state
-  // changes.
+  // Register the calling client as subscriber to a topic, passing a SubscriptionRequest
+  // message containing the desired topic and optional SubscriptionAttributes. 
+  // * Returns a SubscriptionResponse message containing the status of the request,
+  //   along with any event delivery configuration required to consume the event. 
+  // * Calling this endpoint also registers the subscribing client to receive subscription
+  //   change notifications when the subscription state changes.
   rpc Subscribe(SubscriptionRequest) returns (SubscriptionResponse) {
     option (uprotocol.method_id) = 1;
   }
 
-  // The consumer no longer wishes to subscribe to a topic so it issues an
-  // explicit unsubscribe request.
+  // Unregister the calling susbcriber client from a topic.
+  // * Returns a UnsubscripeResponse message containing the updated status of the subscription.
+  // * Calling this endpoint also unregisters the client from receiving subscription change 
+  //   notifications for this subscription.
   rpc Unsubscribe(UnsubscribeRequest) returns (UnsubscribeResponse) {
     option (uprotocol.method_id) = 2;
-  }
-
-  // Fetch a list of subscriptions
-  rpc FetchSubscriptions(FetchSubscriptionsRequest) returns (FetchSubscriptionsResponse) {
-    option (uprotocol.method_id) = 3;
-  }
-
-
-  // Register to receive subscription change notifications that are published on the
-  // 'up:/core.usubscription/3/subscriptions#Update'
-  rpc RegisterForNotifications(NotificationsRequest) returns (NotificationsResponse) {
-    option (uprotocol.method_id) = 6;
-  }
-
-  // Unregister for subscription change events
-  rpc UnregisterForNotifications(NotificationsRequest) returns (NotificationsResponse) {
-    option (uprotocol.method_id) = 7;
   }
 
   // Fetch a list of subscribers that are currently subscribed to a given topic.
@@ -82,80 +65,81 @@ service uSubscription {
     option (uprotocol.method_id) = 8;
   }
 
-  // Reset subscriptions to and from the uSubscription Service.
-  // This API is used between uSubscription services in order to flush and
-  // reestablish subscriptions between devices. A uSubscription service might
-  // ned to call this API if its database is flushed or corrupted (ex. factory
-  // reset).
-  // **__NOTE:__** This is a private API only for uSubscription services,
-  // uEntities can call Unsubscribe() to flush their own subscriptions.
+  // Fetch a list of subscriptions for a given subscriber or topic.
+  rpc FetchSubscriptions(FetchSubscriptionsRequest) returns (FetchSubscriptionsResponse) {
+    option (uprotocol.method_id) = 3;
+  }
+
+  // Register client to receive subscription change notifications for a given topic.
+  rpc RegisterForNotifications(NotificationsRequest) returns (NotificationsResponse) {
+    option (uprotocol.method_id) = 6;
+  }
+
+  // Unregister client from receiving subscription change events for a given topic.
+  rpc UnregisterForNotifications(NotificationsRequest) returns (NotificationsResponse) {
+    option (uprotocol.method_id) = 7;
+  }
+
+  // Reset all subscriber-topic registrations of a uSubscription Service.
+  // A (remote) uSubscription service instance might need to use this API if its 
+  // database gets lost or corrupted (ex. during a factory reset).
+  // * This is a private API, to be used only between uSubscription service entities.
   rpc Reset(ResetRequest) returns (ResetResponse) {
     option (uprotocol.method_id) = 9;
   }
 }
 
-
-// Additional subscription configurations information
+// Subscription configuration information
 message SubscribeAttributes {
-  // When the subscription should expire (time in the future.
-  // **__NOTE:__** If this field is missing, assumed to live forever
+  // Define when the subscription should expire (timestamp should be set in the future).
+  // * If this field is missing, the subscription is assumed to remain valid indefinitely.
+  // * If the timestamp is set in the past when evaluated by uSubscription service, no subscription 
+  //   should be registered and an appropriate result message returned to the caller.
   google.protobuf.Timestamp expire = 1;
 
-  // Any additional producer specific information that the consumer must send
-  // inside of a subscription request
+  // Any additional producer specific information that the consumer needs to send
+  // as part of a subscription request
   repeated google.protobuf.Any details = 2;
 
-  // Desired Sampling Period (measured in milliseconds) the subscriber wishes to receive events
-  // for remote only topics. Device dispatchers (i.e. streamers) use this
-  // attribute to reduce the publication rates of events sent between devices.
-  // This attribute is commonly used for mobile/cloud subscribing to vehicle topics
-  // that are published at a high rate.<br>
-  // If the desired sampling period set by the subscriber is lower than the original publisher's
-  // publication period, the attribute is ignored.<br>
-  // **__NOTE:__** If this attribute is missing, the sampling period is set by the publisher.
+  // Desired sampling period (in milliseconds) the subscriber wishes to receive
+  // events in, applicable only for remote topics. Device dispatchers (i.e. streamers) use
+  // this attribute to reduce the publication rate of messages sent between devices.
+  // This attribute is might e.g. be used by mobile/cloud clients subscribing to in-vehicle 
+  // topics that in their original scope are published at a high rate.
+  // * If the desired sampling period is lower than the original publisher's publication period,
+  //   the attribute is ignored.
+  // * If this attribute is missing, the sampling period is chosen by the publisher.
   optional uint32 sample_period_ms = 3;
 }
 
-
-// Subscriber Identification Information
+// Subscriber identification information
 message SubscriberInfo {
-  // subscriber URI containig the names and numbers of the
-  // uEntities subscribing. Example represented in long form: `//device.domain/com.gm.app.hartley`
+  // URI of the subscribing uEntity. Example represented in long form: `//vin.vehicles/A8000/2/0`
+  // * The resource_id field of SubscriberInfo URIs MUST be 0.
+  // * Wildcard URIs are not permitted.
   uprotocol.v1.UUri uri = 1;
 
-  // DEPRECATED: Any additional device specific subscriber information
-  // repeated google.protobuf.Any details = 2;
   reserved 2;
 }
 
-
-// Subscription Status
+// Subscription status
 message SubscriptionStatus {
   enum State {
-
     UNSUBSCRIBED = 0; // Default state to indicate not subscribed
-
-    SUBSCRIBE_PENDING = 1; // Subscription is pending confirmation from remote
-                              // uSubscription Service
-
+    SUBSCRIBE_PENDING = 1; // Subscription is pending confirmation from remote uSubscription service instance
     SUBSCRIBED = 2; // Subscription has been successful
-
-    UNSUBSCRIBE_PENDING = 3; // Unsubscribe is pending confirmation from the
-                              // remote uSubscription Service
+    UNSUBSCRIBE_PENDING = 3; // Unsubscribe is pending confirmation from remote uSubscription service instance
   }
-
-  reserved 2;
-
   // Subscription state
   State state = 1;
+
+  reserved 2;
 
   // The Subscription status message
   string message = 3;
 }
 
-
-// How events will be delivered to the subscriber. Usage of this structure is
-// device-dependent
+// How events will be delivered to the subscriber. Usage of this structure is device-dependent.
 message EventDeliveryConfig {
   // Identifier for the event delivery endpoint, ex. topic name for events to be published to
   // example for Azure uCloud: "SUBSCRIPTION_TOPIC"
@@ -169,140 +153,124 @@ message EventDeliveryConfig {
   map <string, google.protobuf.Any>  attributes = 3;
 }
 
-
-// Passed to Subscribe() contains the subscription request information
+// Passed to Subscribe() endpoint, this message contains the topic to subscribe to.
 message SubscriptionRequest {
-  // uProtocol uri topic to subscribe too
+  // uProtocol URI of the topic to subscribe to
   uprotocol.v1.UUri topic = 1;
 
-  // DEPRECATED: Subscribers's information (who is calling Subscribe) is not needed
-  //SubscriberInfo subscriber = 2;
   reserved 2;
 
   // Additional subscription attributes
   SubscribeAttributes attributes = 3;
 }
 
-
-// Response message from the Subscribe() API
+// Response message for the Subscribe() endpoint.
 message SubscriptionResponse {
   // Current status of the subscription
   SubscriptionStatus status = 1;
 
-  // Any platform (uDevice) specific additional event delivered configuration
-  // information for how the subscriber should consume the published events.
+  // Any platform-specific event delivery configuration on how the subscriber
+  // should consume published events
   EventDeliveryConfig config = 2;
 
-  // Subscription topic passed to SubscriptionRequest
+  // Subscribed topic, as passed to SubscriptionRequest
   uprotocol.v1.UUri topic = 3;
 }
 
-
-// Passed to the Unsubscribe() API, the message contains the topic to unsubscribe
-// to as well as the subscriber identification
+// Passed to the Unsubscribe() endpoint, this message contains the topic to unsubscribe from.
 message UnsubscribeRequest {
-  // Topic to be unsubscribed to
+  // Topic to unsubscribe from
   uprotocol.v1.UUri topic = 1;
 
-  // DEPRECATED 0Subscriber identification is not needed
-  // SubscriberInfo subscriber = 2;
   reserved 2;
 }
 
-// The (empty) response message representing the successful execution of the Unsubscribe operation.
+// The (empty) response message indicating the execution of the Unsubscribe() operation.
 message UnsubscribeResponse {}
 
-// Passed to FetchSubscribers such that we can obtain a list of subscribers to
-// a particular topic
+// Passed to FetchSubscribers() to obtain a list of subscribers to a given topic.
 message FetchSubscribersRequest {
   reserved 2;
 
-  // Topic we wish to find the subscribers for
+  // Topic to list the subscribers for
   uprotocol.v1.UUri topic = 1;
 }
 
 
-// Returned from FetchSubscribers(), this message contains a repeated list of
-// SubscriberInfo
+// Returned from FetchSubscribers(), this message contains a list of SubscriberInfo elements.
 message FetchSubscribersResponse {
-  reserved 2, 3;
   // List of subscribers
   repeated SubscriberInfo subscribers = 1;
 
-  // Set to true if the batch did not return all records
+  reserved 2, 3;
 }
 
 
-// Subscription Message. Contains all the information about a subscription that
-// is returned from FetchSubscriptions() API.
+// Subscription information message that is returned by FetchSubscriptions() endpoint.
 message Subscription {
   // Subscription topic
   uprotocol.v1.UUri topic = 1;
 
-  // Information about the subscriber who changed their subscription
+  // Information about the subscriber
   SubscriberInfo subscriber = 2;
 
   // Current status of the subscription
   SubscriptionStatus status = 3;
 
-  // Subscribers subscription attributes
+  // Subscriber attributes
   SubscribeAttributes attributes = 4;
 
-  // Any platform (uDevice) specific additional event delivered configuration
-  // information for how the subscriber should consume the published events.
+  // Any platform-specific event delivery configuration on how the subscriber
+  // should consume published events
   EventDeliveryConfig config = 5;
 }
 
-
+// Passed to FetchSubscriptions() to obtain a list of Subscription(s) to a particular topic 
+// or from a given subscriber.
 message FetchSubscriptionsRequest {
-  reserved 3;
-
   oneof request {
-    // Topic to register/unregister to receive subscription change notifications
+    // Topic to return subscribed clients for
     uprotocol.v1.UUri topic = 1;
 
-    // Subscribers's information
+    // Subscriber to return topic subscriptions of
     SubscriberInfo subscriber = 2;
   }
+
+  reserved 3;
 }
 
-
-// Results from FetchSubscriptions() API
+// Results from FetchSubscriptions() endpoint, returning a list of Subscription elements.
 message FetchSubscriptionsResponse {
-  reserved 2;
-
-  // Repeated list of subscriptions for a subscriber
+  // List of subscriptions of a subscriber
   repeated Subscription subscriptions = 1;
-}
 
+  reserved 2;
+}
 
 // Passed to the RegisterForSubscriptionChanges() and UnregisterForSubscriptionChanges()
-// APIs this message includes the topic to register for subscription changes as well
-// as information about the subscriber who wishes to receive said notifications
+// endpoints, this message includes the topic to register for subscription change notifications.
 message NotificationsRequest {
-  // Topic to register/unregister to receive subscription change notifications
+  // Topic to register/unregister subscription change notifications for
   uprotocol.v1.UUri topic = 1;
 
-  // DEPRECATED: Subscribers's information not used as only non-subscribers will call
-  // this API (i.e. producers)
-  // SubscriberInfo subscriber = 2;
   reserved 2;
 }
 
-// The (empty) response message representing the successful execution of the
+// The (empty) response message indicating successful execution of the
 // RegisterForSubscriptionChanges and UnregisterForSubscriptionChanges operations.
 message NotificationsResponse {}
 
 // Subscription Update Message.
-// This Update message is sent from uSusbcription on the topic:
-// '/core.usubscription/3/subscriptions#Update' whenever there is a change to
-// a subscription. Subscribers automatically receive this notification along with
-// any uEntities that called RegisterForNotifications().
+// This Update message is sent by uSusbcription service on the topic:
+// `/core.usubscription/3/subscriptions#Update` whenever there is a change to
+// a subscription.
+// Topic subscribers automatically receive this notification directly, as well as any uEntities 
+// that  explicitly called RegisterForNotifications() for the topics inquestion.
 message Update {
-  // Subscribed topic whos state has changed
+  // Topic the subscription state of which has changed
   uprotocol.v1.UUri topic = 1;
 
-  // Information about the subscriber who changed their subscription
+  // Information about the subscriber who requested the subscription change
   SubscriberInfo subscriber = 2;
 
   // Current status of the subscription
@@ -314,8 +282,6 @@ message Update {
   // Service meta-data option definitions - Resources
   enum Resources { subscriptions = 0; }
 }
-
-
 
 // Passive Subscription Mode.
 // Passive subscriptions, in lieu of active ones, do not modify (the state) nor
@@ -329,9 +295,8 @@ message PassiveMode {
 }
 
 
-// Reset Subscriptions Request.
-// Passed in the Reset() API this message contains the reason for the reset as
-// well as the time before which all subscriptions should be reset.
+// Reset subscriptions request
+// This message can provide the reason for the reset request.
 message ResetRequest {
   // Reason for the reset
   optional Reason reason = 1;
@@ -341,10 +306,9 @@ message ResetRequest {
   // current time is assumed
   //optional google.protobuf.Timestamp before = 2;
   reserved 2;
-  
+
   // The reason for triggering a reset, this is an optional attribute used
-  // to provide insight as to why a reset occurred
-  // More reasons will be added as we distill the business logic
+  // to provide insight as to why a reset occurred.
   message Reason {
     Code code = 1; // Reason code
     optional string message = 2; // Reason message
@@ -358,5 +322,5 @@ message ResetRequest {
   }
 }
 
-// The (empty) response message representing the successful execution of the Reset operation.
+// The (empty) response message indicating the successful execution of the Reset operation.
 message ResetResponse {}

--- a/up-core-api/uprotocol/core/usubscription/v3/usubscription.proto
+++ b/up-core-api/uprotocol/core/usubscription/v3/usubscription.proto
@@ -42,24 +42,6 @@ service uSubscription {
     message: "Update"
   };
 
-  // Register the calling client as subscriber to a topic, passing a SubscriptionRequest
-  // message containing the desired topic and optional SubscriptionAttributes. 
-  // * Returns a SubscriptionResponse message containing the status of the request,
-  //   along with any event delivery configuration required to consume the event. 
-  // * Calling this endpoint also registers the subscribing client to receive subscription
-  //   change notifications when the subscription state changes.
-  rpc Subscribe(SubscriptionRequest) returns (SubscriptionResponse) {
-    option (uprotocol.method_id) = 1;
-  }
-
-  // Unregister the calling susbcriber client from a topic.
-  // * Returns a UnsubscripeResponse message containing the updated status of the subscription.
-  // * Calling this endpoint also unregisters the client from receiving subscription change 
-  //   notifications for this subscription.
-  rpc Unsubscribe(UnsubscribeRequest) returns (UnsubscribeResponse) {
-    option (uprotocol.method_id) = 2;
-  }
-
   // Fetch a list of subscribers that are currently subscribed to a given topic.
   rpc FetchSubscribers(FetchSubscribersRequest) returns (FetchSubscribersResponse) {
     option (uprotocol.method_id) = 8;
@@ -89,103 +71,37 @@ service uSubscription {
   }
 }
 
-// Subscription configuration information
-message SubscribeAttributes {
-  // Define when the subscription should expire (timestamp should be set in the future).
-  // * If this field is missing, the subscription is assumed to remain valid indefinitely.
-  // * If the timestamp is set in the past when evaluated by uSubscription service, no subscription 
-  //   should be registered and an appropriate result message returned to the caller.
-  google.protobuf.Timestamp expire = 1;
-
-  // Any additional producer specific information that the consumer needs to send
-  // as part of a subscription request
-  repeated google.protobuf.Any details = 2;
-
-  // Desired sampling period (in milliseconds) the subscriber wishes to receive
-  // events in, applicable only for remote topics. Device dispatchers (i.e. streamers) use
-  // this attribute to reduce the publication rate of messages sent between devices.
-  // This attribute is might e.g. be used by mobile/cloud clients subscribing to in-vehicle 
-  // topics that in their original scope are published at a high rate.
-  // * If the desired sampling period is lower than the original publisher's publication period,
-  //   the attribute is ignored.
-  // * If this attribute is missing, the sampling period is chosen by the publisher.
-  optional uint32 sample_period_ms = 3;
-}
-
-// Subscriber identification information
-message SubscriberInfo {
-  // URI of the subscribing uEntity. Example represented in long form: `//vin.vehicles/A8000/2/0`
-  // * The resource_id field of SubscriberInfo URIs MUST be 0.
-  // * Wildcard URIs are not permitted.
-  uprotocol.v1.UUri uri = 1;
-
-  reserved 2;
-}
-
-// Subscription status
 message SubscriptionStatus {
   enum State {
-    UNSUBSCRIBED = 0; // Default state to indicate not subscribed
-    SUBSCRIBE_PENDING = 1; // Subscription is pending confirmation from remote uSubscription service instance
-    SUBSCRIBED = 2; // Subscription has been successful
-    UNSUBSCRIBE_PENDING = 3; // Unsubscribe is pending confirmation from remote uSubscription service instance
+    UNSUBSCRIBED = 0;
+    SUBSCRIBE_PENDING = 1;
+    SUBSCRIBED = 2;
+    UNSUBSCRIBE_PENDING = 3;
   }
-  // Subscription state
   State state = 1;
-
   reserved 2;
-
-  // The Subscription status message
   string message = 3;
 }
 
-// How events will be delivered to the subscriber. Usage of this structure is device-dependent.
-message EventDeliveryConfig {
-  // Identifier for the event delivery endpoint, ex. topic name for events to be published to
-  // example for Azure uCloud: "SUBSCRIPTION_TOPIC"
-  string id = 1;
-
-  // What type of endpoint shall be used to deliver the events for said subscription
-  // example for Azure uCloud: "Microsoft.EventHub/Namespaces/EventHubs"
-  string type = 2;
-
-  // Any additional configuration attributes
-  map <string, google.protobuf.Any>  attributes = 3;
-}
-
-// Passed to Subscribe() endpoint, this message contains the topic to subscribe to.
-message SubscriptionRequest {
-  // uProtocol URI of the topic to subscribe to
+// [dsn->impl:req~usubscription-subscribe-signature~1]
+message SubscribeRequest {
   uprotocol.v1.UUri topic = 1;
-
-  reserved 2;
-
-  // Additional subscription attributes
-  SubscribeAttributes attributes = 3;
+  optional uint64 expire_ms = 2;
+  optional uint32 sample_period_ms = 3;
 }
 
-// Response message for the Subscribe() endpoint.
-message SubscriptionResponse {
-  // Current status of the subscription
-  SubscriptionStatus status = 1;
-
-  // Any platform-specific event delivery configuration on how the subscriber
-  // should consume published events
-  EventDeliveryConfig config = 2;
-
-  // Subscribed topic, as passed to SubscriptionRequest
-  uprotocol.v1.UUri topic = 3;
+// [dsn->impl:req~usubscription-subscribe-signature~1]
+message SubscribeResponse {
+  uprotocol.v1.UUri topic = 1;
+  SubscriptionStatus status = 2;
 }
 
-// Passed to the Unsubscribe() endpoint, this message contains the topic to unsubscribe from.
+// [dsn->impl:req~usubscription-unsubscribe-signature~1]
 message UnsubscribeRequest {
-  // Topic to unsubscribe from
   uprotocol.v1.UUri topic = 1;
-
-  reserved 2;
 }
 
-// The (empty) response message indicating the execution of the Unsubscribe() operation.
+// [dsn->impl:req~usubscription-unsubscribe-signature~1]
 message UnsubscribeResponse {}
 
 // Passed to FetchSubscribers() to obtain a list of subscribers to a given topic.
@@ -200,7 +116,7 @@ message FetchSubscribersRequest {
 // Returned from FetchSubscribers(), this message contains a list of SubscriberInfo elements.
 message FetchSubscribersResponse {
   // List of subscribers
-  repeated SubscriberInfo subscribers = 1;
+  repeated uprotocol.v1.UUri subscribers = 1;
 
   reserved 2, 3;
 }
@@ -208,21 +124,11 @@ message FetchSubscribersResponse {
 
 // Subscription information message that is returned by FetchSubscriptions() endpoint.
 message Subscription {
-  // Subscription topic
   uprotocol.v1.UUri topic = 1;
-
-  // Information about the subscriber
-  SubscriberInfo subscriber = 2;
-
-  // Current status of the subscription
+  uprotocol.v1.UUri subscriber = 2;
   SubscriptionStatus status = 3;
-
-  // Subscriber attributes
-  SubscribeAttributes attributes = 4;
-
-  // Any platform-specific event delivery configuration on how the subscriber
-  // should consume published events
-  EventDeliveryConfig config = 5;
+  optional uint64 expire_ms = 4;
+  optional uint32 sample_period_ms = 5;
 }
 
 // Passed to FetchSubscriptions() to obtain a list of Subscription(s) to a particular topic 
@@ -233,7 +139,7 @@ message FetchSubscriptionsRequest {
     uprotocol.v1.UUri topic = 1;
 
     // Subscriber to return topic subscriptions of
-    SubscriberInfo subscriber = 2;
+    uprotocol.v1.UUri subscriber = 2;
   }
 
   reserved 3;
@@ -267,17 +173,11 @@ message NotificationsResponse {}
 // Topic subscribers automatically receive this notification directly, as well as any uEntities 
 // that  explicitly called RegisterForNotifications() for the topics inquestion.
 message Update {
-  // Topic the subscription state of which has changed
   uprotocol.v1.UUri topic = 1;
-
-  // Information about the subscriber who requested the subscription change
-  SubscriberInfo subscriber = 2;
-
-  // Current status of the subscription
+  uprotocol.v1.UUri subscriber = 2;
   SubscriptionStatus status = 3;
-
-  // Subscribers subscription attributes
-  SubscribeAttributes attributes = 4;
+  optional uint64 expire_ms = 4;
+  optional uint32 sample_period_ms = 5;
 
   // Service meta-data option definitions - Resources
   enum Resources { subscriptions = 0; }

--- a/up-l3/usubscription/v3/README.adoc
+++ b/up-l3/usubscription/v3/README.adoc
@@ -3,6 +3,7 @@
 :sectnums:
 :usubscription_proto_link: link:../../../up-core-api/uprotocol/core/usubscription/v3/usubscription.proto[usubscription.proto]
 :communication_layer_api_ref: xref:../../../up-l2/api.adoc[Communication Layer API] 
+:basic_types_ref: xref:../../../basics/README.adoc[uProtocol Basic Types]
 :uuri_ref: xref:../../../basics/uri.adoc[UURI]
 :ucode_ref: link:../../../up-core-api/uprotocol/v1/ucode.proto[UCode]
 
@@ -42,10 +43,29 @@ A distributed publish-subscribe network requires the following capabilities to b
 
 The remainder of this document defines the use cases, interfaces, state machines and application flows to support cross-system tracking of subscriptions, especially to/from remote systems.
 
+---
+
 [.specitem,oft-sid="dsn~usubscription-service_name~1",oft-needs="impl,utest"]
 The uSubscription service name *MUST* be `core.usubscription`.
 
-NOTE: The UCode and UUri classes are defined in detail in {ucode_ref} and uProtocol {uuri_ref} specifications.
+[.specitem,oft-sid="dsn~usubscription-uentity_id~1",oft-needs="impl,utest"]
+The uSubscription service uEntity Identifier (`ue_id`) *MUST* be 0.
+
+The USubscription service API is defined using UML2 notation.
+
+[mermaid]
+ifdef::env-github[[source,mermaid]]
+----
+classDiagram
+class USubscription {
+    subscribe(topic: UUri, expiry: UInt64[0..1], sample-period: UInt32[0..1]) topic: UURI, status: SubscriptionStatus
+    unsubscribe(topic: UUri)
+}
+----
+
+---
+
+NOTE: The data types used in the following sections are defined in {basic_types_ref}.
 
 [#usubscription-local-remote-subscriptions]
 == Local and Remote Subscriptions
@@ -78,10 +98,12 @@ In addition to performing the actions necessary to subscribe to and receive mess
 [#subscribe-operation]
 === Subscribe()
 
-// [.specitem,oft-sid="dsn~usubscription-subscribe-protobuf~1",oft-needs="impl,utest"]
-// The uSubscription service `Subscribe()` function *MUST* implement the corresponding protobuf definition in {usubscription_proto_link}.
+[source]
+----
+subscribe(topic: UUri, expiry: UInt64[0..1], sample-period: UInt32[0..1])
+----
 
-Register the calling client as subscriber to a topic. 
+Clients use this method to subscribe to a topic. 
 
 * Returns the status of the requested subscription. 
 * Calling this endpoint also registers the subscribing client to receive subscription change notifications when the subscription status changes.
@@ -92,43 +114,16 @@ The uSubscription service `Subscribe()` function *MUST* use the method ID 1.
 [.specitem,oft-sid="req~usubscription-subscribe-signature~1",oft-needs="dsn,impl,utest"]
 The uSubscription service `Subscribe()` function *MUST* implement the following message definitions:
 
-.Subscribe() function request parameters
-[#subscribe-request-data-model]
-[mermaid]
-ifdef::env-github[[source,mermaid]]
-----
-classDiagram
-class Subscribe {
-        <<Interface>>
-}
-
-class SubscribeRequest {
-    <<UMessage>>
-    topic : UURI
-    expiry : UInt64[0..1]
-    sample-period : UInt32[0..1]
-}
-class SubscribeResponse {
-    <<UMessage>>
-    topic : UURI
-    status : SubscriptionStatus
-}
-
-Subscribe ..> SubscribeRequest : request message
-Subscribe ..> SubscribeResponse : response message
-----
-
 ---
 
-The following table provides detailed descriptions of the SubscribeRequest attributes:
-
+.Subscribe Request Parameters
 [%autowidth]
 |===
-|Name |Type |Mandatory |Description
+|Parameter | Type | Mandatory | Description
 
-|`topic`
-|{uuri_ref}
-|yes
+| topic
+| {uuri_ref}
+| yes
 a|
 --
 uProtocol URI of the topic to subscribe to.
@@ -165,10 +160,8 @@ topics that in their original scope are published at a high rate.
 
 |===
 
----
 
-The following table provides detailed description of the SubscribeResponse attributes:
-
+.Subscribe Response Parameters
 [%autowidth]
 |===
 |Name |Type |Description
@@ -224,16 +217,60 @@ When a client calls the `Subscribe()` function for a remote topic that is in sta
 [.specitem,oft-sid="req~usubscription-subscribe-notifications~1",oft-needs="impl,utest"]
 When a client calls the `Subscribe()` function, uSubscription service *MUST* generate subscription change notifications reflecting any changes to the subscription state of the subscribed topic.
 
+---
+
+[discrete]
+==== Subscribe operation
+[mermaid]
+ifdef::env-github[[source,mermaid]]
+----
+sequenceDiagram
+
+actor C as Client
+participant T as USubscription Service
+
+C->>T : subscribe(topic: UUri)
+activate T
+T--)C : topic: UUri, status: SubscriptionStatus
+deactivate T
+----
+
+---
+
+[discrete]
+==== Subscribe operation with expiration time
+[mermaid]
+ifdef::env-github[[source,mermaid]]
+----
+sequenceDiagram
+
+actor C as Client
+participant T as USubscription Service
+participant N as Notification Channel
+
+C->>T : subscribe(topic: UUri, expiry: UInt64)
+activate T
+T--)C : topic: UUri, status: SubscriptionStatus
+T-->T : await expiry
+T->>C : update(topic: UUri, subscriber: UUri, status: SubscriptionStatus::UNSUBSCRIBED)
+T--)N : update(topic: UUri, subscriber: UUri, status: SubscriptionStatus::UNSUBSCRIBED)
+deactivate T
+----
+
+---
+
 [#unsubscribe-operation]
 === Unsubscribe()
 
-Unregister the calling client as subscriber to a topic. 
+[source]
+----
+unsubscribe(topic: UUri)
+----
+
+Clients use this method to unsubscribe from a topic. 
 
 * Always succeeds from the client's point of view; uSubscription service will set the subscription status to 'UNSUBSCRIBED' upon receiving an Unsubscribe() request.
 * Calling this endpoint unregisters the client from receive subscription change notifications when the subscription status changes.
-
-// [.specitem,oft-sid="dsn~usubscription-unsubscribe-protobuf~1",oft-needs="impl,utest"]
-// The uSubscription service `Unsubscribe()` function *MUST* implement the corresponding protobuf definition in {usubscription_proto_link}.
 
 [.specitem,oft-sid="dsn~usubscription-unsubscribe-method_id~1",oft-needs="impl,utest"]
 The uSubscription service `Subscribe()` function *MUST* use the method ID 2.
@@ -241,32 +278,9 @@ The uSubscription service `Subscribe()` function *MUST* use the method ID 2.
 [.specitem,oft-sid="req~usubscription-unsubscribe-signature~1",oft-needs="dsn,impl,utest"]
 The uSubscription service `Unsubscribe()` function *MUST* implement the following message definitions:
 
-.Unsubscribe() function request parameters
-[#unsubscribe-data-model]
-[mermaid]
-ifdef::env-github[[source,mermaid]]
-----
-classDiagram
-class Unsubscribe {
-        <<Interface>>
-}
-
-class UnsubscribeRequest {
-    <<UMessage>>
-    topic : UURI
-}
-class UnsubscribeResponse {
-    <<UMessage>>
-}
-
-Unsubscribe ..> UnsubscribeRequest : request message
-Unsubscribe ..> UnsubscribeResponse : response message
-----
-
 ---
 
-The following table provides detailed description of the UnsubscribeRequest attributes:
-
+.Unsubscribe Request Parameters
 [%autowidth]
 |===
 |Name |Type |Mandatory |Description
@@ -299,6 +313,24 @@ When a client calls the `Unsubscribe()` function for a remote topic that is in s
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-notifications~1",oft-needs="impl,utest"]
 When the last client subscribed to a topic calls the `Unsubscribe()` function on that topic, uSubscription service *MUST* stop generating subscription change notifications for that topic.
+
+---
+
+[mermaid]
+ifdef::env-github[[source,mermaid]]
+----
+sequenceDiagram
+
+actor C as Client
+participant T as USubscription Service
+
+C->>T : unsubscribe(topic: UUri)
+activate T
+T--)C : ()
+deactivate T
+----
+
+---
 
 [#fetch-subscribers-operation]
 === FetchSubscribers()

--- a/up-l3/usubscription/v3/README.adoc
+++ b/up-l3/usubscription/v3/README.adoc
@@ -49,7 +49,7 @@ The remainder of this document defines the use cases, interfaces, state machines
 The uSubscription service name *MUST* be `core.usubscription`.
 
 [.specitem,oft-sid="dsn~usubscription-uentity_id~1",oft-needs="impl,utest"]
-The uSubscription service uEntity Identifier (`ue_id`) *MUST* be 0.
+The uSubscription service uEntity Identifier (`ue_id`) *MUST* be 0x0000.
 
 The USubscription service API is defined using UML2 notation.
 
@@ -58,9 +58,19 @@ ifdef::env-github[[source,mermaid]]
 ----
 classDiagram
 class USubscription {
-    subscribe(topic: UUri, expiry: UInt64[0..1], sample-period: UInt32[0..1]) topic: UURI, status: SubscriptionStatus
+    <<interface>>
+    subscribe(topic: UUri, expiry: UInt64 [0..1], sample-period: UInt32 [0..1]) UUri, SubscriptionStatus
     unsubscribe(topic: UUri)
 }
+class SubscriptionStatus {
+    <<enumeration>>
+    unsubscribed
+    subscribePending
+    subscribed
+    unsubscribePending
+}
+USubscription ..> SubscriptionStatus
+
 ----
 
 ---
@@ -100,7 +110,7 @@ In addition to performing the actions necessary to subscribe to and receive mess
 
 [source]
 ----
-subscribe(topic: UUri, expiry: UInt64[0..1], sample-period: UInt32[0..1])
+subscribe(topic: UUri, expiry: UInt64[0..1], sample-period: UInt32[0..1]) : UUri, SubscriptionStatus
 ----
 
 Clients use this method to subscribe to a topic. 
@@ -137,7 +147,7 @@ Also refer to xref:topic-uuris[Topic UURIs] regarding specific restrictions on t
 a|
 [.specitem,oft-sid="dsn~usubscription-subscribe-past_expiry~1",oft-needs="impl,utest",oft-tags="uSubscription"]
 --
-Define when the subscription should expire, in millisecond granularity (timestamp should be set in the future).
+Define when the subscription should expire, in millisecond since the start of https://en.wikipedia.org/wiki/Unix_time[Unix time]. This timestamp should be set in the future, otherwise no subscription will be registered.
 
 * If this field is missing, the subscription is assumed to remain valid indefinitely.
 * If the timestamp is set in the past when evaluated by uSubscription service, it *MUST NOT* register the subscription and return `UNSUBSCRIBED` as subscription status.
@@ -164,16 +174,14 @@ topics that in their original scope are published at a high rate.
 .Subscribe Response Parameters
 [%autowidth]
 |===
-|Name |Type |Description
+|Type |Description
 
-|`topic`
 |{uuri_ref}
 a|
 --
 Subscribed topic, as passed to SubscriptionRequest
 --
 
-|`status`
 |xref:SubscriptionStatus[SubscriptionStatus]
 a|
 --
@@ -229,9 +237,9 @@ sequenceDiagram
 actor C as Client
 participant T as USubscription Service
 
-C->>T : subscribe(topic: UUri)
+C->>T : subscribe("up://vehicle/A1B/1/9A10")
 activate T
-T--)C : topic: UUri, status: SubscriptionStatus
+T--)C : "up://vehicle/A1B/1/9A10", SubscriptionStatus.subscribed
 deactivate T
 ----
 
@@ -248,12 +256,12 @@ actor C as Client
 participant T as USubscription Service
 participant N as Notification Channel
 
-C->>T : subscribe(topic: UUri, expiry: UInt64)
+C->>T : subscribe("up://vehicle/A1B/1/9A10", 1780923819000)
 activate T
-T--)C : topic: UUri, status: SubscriptionStatus
+T--)C : "up://vehicle/A1B/1/9A10", SubscriptionStatus.subscribed
 T-->T : await expiry
-T->>C : update(topic: UUri, subscriber: UUri, status: SubscriptionStatus::UNSUBSCRIBED)
-T--)N : update(topic: UUri, subscriber: UUri, status: SubscriptionStatus::UNSUBSCRIBED)
+T->>C : update("up://vehicle/A1B/1/9A10", "up://client/10A0/3", SubscriptionStatus.unsubscribed)
+T--)N : update("up://vehicle/A1B/1/9A10", "up://client/10A0/3", SubscriptionStatus.unsubscribed)
 deactivate T
 ----
 

--- a/up-l3/usubscription/v3/README.adoc
+++ b/up-l3/usubscription/v3/README.adoc
@@ -5,7 +5,10 @@
 :communication_layer_api_ref: xref:../../../up-l2/api.adoc[Communication Layer API] 
 :basic_types_ref: xref:../../../basics/README.adoc[uProtocol Basic Types]
 :uuri_ref: xref:../../../basics/uri.adoc[UURI]
-:ucode_ref: link:../../../up-core-api/uprotocol/v1/ucode.proto[UCode]
+:uattributes_ref: link:../../../basics/uattributes.adoc[UAttributes]
+:umessage_ref: link:../../../basics/umessage.adoc[UMessage]
+:ucode_proto_ref: link:../../../up-core-api/uprotocol/v1/ucode.proto[UCode]
+
 
 The key words "*MUST*", "*MUST NOT*", "*REQUIRED*", "*SHALL*", "*SHALL NOT*", "*SHOULD*", "*SHOULD NOT*", "*RECOMMENDED*", "*MAY*", and "*OPTIONAL*" in this document are to be interpreted as described in https://www.rfc-editor.org/info/bcp14[IETF BCP14 (RFC2119 & RFC8174)]
 
@@ -23,13 +26,11 @@ SPDX-FileType: DOCUMENTATION
 SPDX-License-Identifier: Apache-2.0
 ----
 
-****
-This specification defines formal requirements for the implementation of a uProtocol uSubscription service. Requirements are highlighted by a frame, like this.
-****
+This specification defines formal requirements for the implementation of a uProtocol uSubscription service. 
 
 == Overview
 
-The https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern[Publish & Subscribe (_pubsub_) architecture pattern] allows the decoupling of senders and receives of messages on the levels of code-dependency, sender-receiver relationship, deployment context, network topology and even temporal coincidence. There exist a large number of implementations of this pattern for all sorts of domains and requirements, both in open source and proprietary development models.
+The https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern[Publish & Subscribe (_pubsub_) architecture pattern] allows the decoupling of senders and receivers of messages on the levels of code-dependency, sender-receiver relationship, deployment context, network topology and even temporal coincidence. There exist a large number of implementations of this pattern for all sorts of domains and requirements, both in open source and proprietary development models.
 
 The purpose of uProtocol is to be the overarching service fabric/backbone of an automotive service landscape that extends from in-vehicle mechatronics devices and in-vehicle high-compute systems all the way up to cloud-based backend services and mobile-device companion applications. As such, uProtocol needs to be integrative towards any specific pubsub implementation that might be used in such a broad scenario (ex. MQTT, Eclipse Zenoh, DDS, SOME/IP, etc): uProtocol requires the facilities to implement a distributed publish-subscribe architecture.
 
@@ -37,22 +38,18 @@ A distributed publish-subscribe network requires the following capabilities to b
  
 - xref:../../../basics/uri.adoc[unified addressing] scheme
 - xref:../../../up-l2/dispatchers/README.adoc[message forwarding] between different pub-sub domains
-- xref:../../udiscovery/v3/README.adoc[discoverability] of available publishers/publications
-- cross-system tracking of subscriptions, especially to/from remote systems (this specification)
+- xref:../../udiscovery/v3/README.adoc[discoverability] of available publishers/topics
+- tracking of subscriptions, especially to/from remote systems (this specification)
 - option for xref:../../utwin/v2/README.adoc[local caching and temporally decoupled access] to published data
 
-The remainder of this document defines the use cases, interfaces, state machines and application flows to support cross-system tracking of subscriptions, especially to/from remote systems.
+The remainder of this document defines the use cases, interfaces, state machines and application flows to support tracking of subscriptions, including between remote/distributed systems.
 
 ---
 
-[.specitem,oft-sid="dsn~usubscription-service_name~1",oft-needs="impl,utest"]
-The uSubscription service name *MUST* be `core.usubscription`.
+The uSubscription service API is defined using UML2 notation.
 
-[.specitem,oft-sid="dsn~usubscription-uentity_id~1",oft-needs="impl,utest"]
-The uSubscription service uEntity Identifier (`ue_id`) *MUST* be 0x0000.
-
-The USubscription service API is defined using UML2 notation.
-
+.USubscription API
+[#usubscription-api]
 [mermaid]
 ifdef::env-github[[source,mermaid]]
 ----
@@ -64,10 +61,10 @@ class USubscription {
 }
 class SubscriptionStatus {
     <<enumeration>>
-    unsubscribed
-    subscribePending
-    subscribed
-    unsubscribePending
+    UNSUBSCRIBED
+    SUBSCRIBE_PENDING
+    UNSUBSCRIBED
+    UNSUBSCRIBE_PENDING
 }
 USubscription ..> SubscriptionStatus
 
@@ -75,14 +72,22 @@ USubscription ..> SubscriptionStatus
 
 ---
 
-NOTE: The data types used in the following sections are defined in {basic_types_ref}.
+NOTE: The data types used in the following sections are defined in {basic_types_ref}. 
 
-[#usubscription-local-remote-subscriptions]
+---
+
+[.specitem,oft-sid="dsn~usubscription-service_name~1",oft-needs="impl,utest"]
+The uSubscription service name *MUST* be `core.usubscription`.
+
+[.specitem,oft-sid="dsn~usubscription-uentity_id~1",oft-needs="impl,utest"]
+The uSubscription service uEntity type identifier *MUST* be `0x0000`.
+
+[#local-remote-subscriptions]
 == Local and Remote Subscriptions
 
 In a distributed pubsub network, there exist two subscription scenarios: local subscriptions and remote subscriptions. 
 
-In the local case a client subscribes to messages published by a uEntity (might be abbreviated as `uE`, especially in diagrams) on the same transport network, both parties using the same pubsub implementation. For instance, imagine an MQTT broker used by publishers and subscribers, all deployed within the same system context.
+In the local case a client subscribes to messages published by a _uEntity_ (might be abbreviated as _uE_, especially in diagrams) on the same transport network, with both parties using the same pubsub implementation. For instance, imagine an MQTT broker used by publishers and subscribers, all deployed within the same system context.
 
 In contrast, a remote subscription scenario involves publishers and subscribers using different pubsub implementations and/or being located on different systems. For instance, a client interacting with a co-located MQTT broker to subscribe to messages that originate from a low-level mechatronics device, being published via SOME/IP.
 
@@ -119,7 +124,7 @@ Clients use this method to subscribe to a topic.
 * Calling this endpoint also registers the subscribing client to receive subscription change notifications when the subscription status changes.
 
 [.specitem,oft-sid="dsn~usubscription-subscribe-method_id~1",oft-needs="impl,utest"]
-The uSubscription service `Subscribe()` function *MUST* use the method ID 1.
+The uSubscription service `Subscribe()` function *MUST* use the method ID `1`.
 
 [.specitem,oft-sid="req~usubscription-subscribe-signature~1",oft-needs="dsn,impl,utest"]
 The uSubscription service `Subscribe()` function *MUST* implement the following message definitions:
@@ -150,7 +155,7 @@ a|
 Define when the subscription should expire, in millisecond since the start of https://en.wikipedia.org/wiki/Unix_time[Unix time]. This timestamp should be set in the future, otherwise no subscription will be registered.
 
 * If this field is missing, the subscription is assumed to remain valid indefinitely.
-* If the timestamp is set in the past when evaluated by uSubscription service, it *MUST NOT* register the subscription and return `UNSUBSCRIBED` as subscription status.
+* If the timestamp is set in the past when evaluated by uSubscription service, it *MUST NOT* register the subscription and return xref:subscription-status[SubscriptionStatus] `UNSUBSCRIBED`.
 --
 
 |`sample-period`
@@ -159,10 +164,8 @@ Define when the subscription should expire, in millisecond since the start of ht
 a|
 --
 Desired sampling period (in milliseconds) the subscriber wishes to receive
-events in, applicable only for remote topics. Device dispatchers (i.e. streamers) use
-this attribute to reduce the publication rate of messages sent between devices.
-This attribute is might e.g. be used by mobile/cloud clients subscribing to in-vehicle 
-topics that in their original scope are published at a high rate.
+events in, applicable only for remote topics. Device dispatchers (`uStreamers`) use this attribute to reduce the publication rate of messages sent between devices.
+This attribute is might e.g. be used by mobile/cloud clients subscribing to in-vehicle topics that in their original scope are published at a high rate.
 
 * If the desired sampling period is lower than the original publisher's publication period, the attribute is ignored.
 * If this attribute is missing, the sampling period is chosen by the publisher.
@@ -193,10 +196,10 @@ Current status of the subscription.
 ---
 
 [.specitem,oft-sid="req~usubscription-subscribe~1",oft-needs="impl,utest"]
-When a client calls the `Subscribe()` function, uSubscription service *MUST* start tracking the client as a subscriber to the topic provided with the function call.
+When a client calls the `Subscribe()` function, uSubscription service *MUST* start tracking the client as a subscriber to the indicated topic.
 
 [.specitem,oft-sid="req~usubscription-subscribe-persistency~1",oft-needs="impl,utest"]
-When a client calls the `Subscribe()` function, uSubscription service *MUST* persistenly (across service restarts) store the client as a subscriber of the provided topic.
+When a client calls the `Subscribe()` function, uSubscription service *MUST* persistenly (across service restarts) store the client as a subscriber of the indicated topic.
 
 [.specitem,oft-sid="req~usubscription-subscribe-expiration~1",oft-needs="impl,utest"]
 When the subscription expiration time is exceeded, uSubscription service *MUST* stop tracking the associated client-topic subscription.
@@ -205,25 +208,28 @@ When the subscription expiration time is exceeded, uSubscription service *MUST* 
 When a subscription request does not specify an expiration time, uSubscription service *MUST* track the associated client-topic subscription indefinitely and persistently (across service restarts).
 
 [.specitem,oft-sid="req~usubscription-subscribe-multiple~1",oft-needs="impl,utest"]
-When a client calls the `Subscribe()` function for a topic that it is already subscribed to, uSubscription service *MUST* return a response message containing the current subscription status for this client-topic combination (e.g. `SUBSCRIBED` or `SUBSCRIBE_PENDING`).
+When a client calls the `Subscribe()` function for a topic that it is already subscribed to, uSubscription service *MUST* return a response message containing the current xref:subscription-status[SubscriptionStatus] of this client-topic combination (e.g. `SUBSCRIBED` or `SUBSCRIBE_PENDING`).
 
 [.specitem,oft-sid="req~usubscription-subscribe-expiration-extension~1",oft-needs="impl,utest"]
 When a client calls the `Subscribe()` function for a topic that it is already subscribed to where the `expire` field value differs from the current expiration time, uSubscription service *MUST* update the expiration time of the subscription with the new value.
 
+[.specitem,oft-sid="req~usubscription-subscribe-expiration-extension-past~1",oft-needs="impl,utest"]
+When a client calls the `Subscribe()` function for a topic that it is already subscribed to where the `expire` field value differs from the current expiration time and lies in the past, uSubscription service *MUST* unregister the subscription and return xref:subscription-status[SubscriptionStatus] `UNSUBSCRIBED`.
+
 [.specitem,oft-sid="req~usubscription-subscribe-remote~1",oft-needs="impl,utest"]
-When a client makes the first call to `Subscribe()` to a _remote_ topic, i.e. a topic that is not published by a uEntity on the local host, uSubscription service *MUST* establish a remote subscription to that topic by sending a `Subscribe()` request to the (remote) uSubscription service running on the host indicated by the remote topic's _authority_. 
+When a client makes the first call to `Subscribe()` to a xref:local-remote-subscriptions[remote] topic, uSubscription service *MUST* establish a remote subscription to that topic by sending a `Subscribe()` request to the uSubscription service running on the host indicated by the remote topic's _authority_. 
 
 [.specitem,oft-sid="req~usubscription-subscribe-remote-pending~1",oft-needs="impl,utest"]
-When uSubscription service sends a `Subscribe()` request to a remote uSubscription service, uSubscription service *MUST* set the subscription state for any client-topic combination involving the subscribed remote topic to `SUBSCRIBE_PENDING`.
+When uSubscription service sends a `Subscribe()` request to a remote uSubscription service, uSubscription service *MUST* set the xref:subscription-status[SubscriptionStatus] for any client-topic combination involving the subscribed remote topic to `SUBSCRIBE_PENDING`.
 
 [.specitem,oft-sid="req~usubscription-subscribe-remote-response~1",oft-needs="impl,utest"]
-When uSubscription service receives a reply to a remote `Subscribe()` request, uSubscription service *MUST* set the subscription state for any client-topic combination involving the subscribed remote topic to match the subscription status response of the remote uSubscription service (e.g. `SUBSCRIBED` or `UNSUBSCRIBED`).
+When uSubscription service receives a reply to a remote `Subscribe()` request, uSubscription service *MUST* set the xref:subscription-status[SubscriptionStatus] for any client-topic combination involving the subscribed remote topic to match the subscription status response of the remote uSubscription service (e.g. `SUBSCRIBED` or `UNSUBSCRIBED`).
 
 [.specitem,oft-sid="req~usubscription-subscribe-unsubscribe-pending~1",oft-needs="impl,utest"]
-When a client calls the `Subscribe()` function for a remote topic that is in state `UNSUBSCRIBE_PENDING`, uSubscription service *MUST* initiate the regular remote subscription process, i.e. send a subscription request to the remote uSubscription service and set status to `SUBSCRIBE_PENDING`.
+When a client calls the `Subscribe()` function for a remote topic with xref:subscription-status[SubscriptionStatus] `UNSUBSCRIBE_PENDING`, uSubscription service *MUST* initiate the regular remote subscription process, i.e. send a subscription request to the remote uSubscription service and set xref:subscription-status[SubscriptionStatus] to `SUBSCRIBE_PENDING`.
 
 [.specitem,oft-sid="req~usubscription-subscribe-notifications~1",oft-needs="impl,utest"]
-When a client calls the `Subscribe()` function, uSubscription service *MUST* generate subscription change notifications reflecting any changes to the subscription state of the subscribed topic.
+After a client calls the `Subscribe()` function, uSubscription service *MUST* send subscription change notifications ({umessage_ref} type `UMESSAGE_TYPE_NOTIFICATION`) to that client, reflecting any changes to the subscription state of the subscribed topic.
 
 ---
 
@@ -239,7 +245,7 @@ participant T as USubscription Service
 
 C->>T : subscribe("up://vehicle/A1B/1/9A10")
 activate T
-T--)C : "up://vehicle/A1B/1/9A10", SubscriptionStatus.subscribed
+T--)C : "up://vehicle/A1B/1/9A10", SubscriptionStatus.SUBSCRIBED
 deactivate T
 ----
 
@@ -258,10 +264,10 @@ participant N as Notification Channel
 
 C->>T : subscribe("up://vehicle/A1B/1/9A10", 1780923819000)
 activate T
-T--)C : "up://vehicle/A1B/1/9A10", SubscriptionStatus.subscribed
+T--)C : "up://vehicle/A1B/1/9A10", SubscriptionStatus.SUBSCRIBED
 T-->T : await expiry
-T->>C : update("up://vehicle/A1B/1/9A10", "up://client/10A0/3", SubscriptionStatus.unsubscribed)
-T--)N : update("up://vehicle/A1B/1/9A10", "up://client/10A0/3", SubscriptionStatus.unsubscribed)
+T->>C : update("up://vehicle/A1B/1/9A10", "up://client/10A0/3", SubscriptionStatus.UNSUBSCRIBED)
+T--)N : update("up://vehicle/A1B/1/9A10", "up://client/10A0/3", SubscriptionStatus.UNSUBSCRIBED)
 deactivate T
 ----
 
@@ -277,11 +283,11 @@ unsubscribe(topic: UUri)
 
 Clients use this method to unsubscribe from a topic. 
 
-* Always succeeds from the client's point of view; uSubscription service will set the subscription status to 'UNSUBSCRIBED' upon receiving an Unsubscribe() request.
+* Always succeeds from the client's point of view; uSubscription service will set the xref:subscription-status[SubscriptionStatus] to 'UNSUBSCRIBED' upon receiving an Unsubscribe() request.
 * Calling this endpoint unregisters the client from receive subscription change notifications when the subscription status changes.
 
 [.specitem,oft-sid="dsn~usubscription-unsubscribe-method_id~1",oft-needs="impl,utest"]
-The uSubscription service `Subscribe()` function *MUST* use the method ID 2.
+The uSubscription service `Unsubscribe()` function *MUST* use the method ID `2`.
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-signature~1",oft-needs="dsn,impl,utest"]
 The uSubscription service `Unsubscribe()` function *MUST* implement the following message definitions:
@@ -308,19 +314,19 @@ Also refer to xref:topic-uuris[Topic UURIs] regarding specific restrictions on t
 ---
 
 [.specitem,oft-sid="req~usubscription-unsubscribe~1",oft-needs="impl,utest"]
-When a client calls the `Unsubscribe()` function, uSubscription service *MUST* stop tracking the client as a subscriber to the topic provided with the function call.
+When a client calls the `Unsubscribe()` function, uSubscription service *MUST* stop tracking the client as a subscriber to the indicated topic.
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-last-remote~1",oft-needs="impl,utest"]
 When the last client subscribed to a remote topic calls the `Unsubscribe()` function on that topic, uSubscription service *MUST* perform a remote unsubscribe on that topic by sending an `Unsubscribe()` request to the remote uSubscription service. 
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-remote-unsubscribed~1",oft-needs="impl,utest"]
-When sending an `Unsubscribe()` request to a remote uSubscription service, uSubscription service *MUST* consider the remote topic to be in state `UNSUBSCRIBED`, regardless of the status returned from the remote uSubscription service.
+When sending an `Unsubscribe()` request to a remote uSubscription service, uSubscription service *MUST* consider the remote topic xref:subscription-status[SubscriptionStatus] to be `UNSUBSCRIBED`, regardless of the status returned from the remote uSubscription service.
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-subscribe-pending~1",oft-needs="impl,utest"]
-When a client calls the `Unsubscribe()` function for a remote topic that is in state `SUBSCRIBE_PENDING`, uSubscription service *MUST* initiate the regular remote unsubscribe process, i.e. send an unsubscribe request to the remote uSubscription service and set status to `UNSUBSCRIBED`.
+When a client calls the `Unsubscribe()` function for a remote topic with xref:subscription-status[SubscriptionStatus] `SUBSCRIBE_PENDING`, uSubscription service *MUST* initiate the regular remote unsubscribe process, i.e. send an unsubscribe request to the remote uSubscription service and set xref:subscription-status[SubscriptionStatus] to `UNSUBSCRIBED`.
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-notifications~1",oft-needs="impl,utest"]
-When the last client subscribed to a topic calls the `Unsubscribe()` function on that topic, uSubscription service *MUST* stop generating subscription change notifications for that topic.
+When the last client subscribed to a topic calls the `Unsubscribe()` function on that topic, uSubscription service *MUST* stop publishing subscription update messages for that topic.
 
 ---
 
@@ -427,7 +433,7 @@ stateDiagram-v2
 uSubscription service *MUST* implement subscription state transisitions of client-topic subscription relationships according to the above xref:usubscription-state-machine[state diagram].
 ****
 
-NOTE: `SUBSCRIBE_PENDING` and `UNSUBSCRIBE_PENDING` states only apply to link:#usubscription-local-remote-subscriptions[remote topic subscriptions], more details provided below.
+NOTE: `SUBSCRIBE_PENDING` and `UNSUBSCRIBE_PENDING` xref:subscription-status[SubscriptionStatus] only applies to link:#usubscription-local-remote-subscriptions[remote topic subscriptions], more details provided below.
 
 .Subscription State Details
 [width="100%",cols="17%,20%,19%,26%,18%",options="header",]
@@ -454,7 +460,7 @@ a|* Received a (positive) response from the remote uSubscription service
 
 | `*UNSUBSCRIBE_PENDING*`
 |Unsubscribe is pending, awaiting acknowledgement from the remote uSubscription service
-a|* Last subscriber called `Unsubscribe(topic)` on a `SUBSCRIBED` remote topic`
+a|* Last subscriber called `Unsubscribe(topic)` on a xref:subscription-status[SubscriptionStatus] `SUBSCRIBED` remote topic`
 a|* Send an unsubscribe request to the remote uSubscription service
 a|* Received a (positive) response from the remote uSubscription service
 
@@ -515,7 +521,7 @@ uSubscription service *MUST* stop sending subscription change notifications to c
 
 == Timeout & Retry Logic
 
-Subscribe (and unsubscribe) to remote topics are handled by RPC calls between uSubscription services running on the different devices. Given that devices are not always connected to each other, the onus is on uSubscription service to ensure that a command is received in time. Below are the common retry and timeout policies for USubscription service implementations to follow:   
+Subscribe (and unsubscribe) to remote topics are handled by RPC calls between uSubscription services running on the different devices. Given that devices are not always connected to each other, the onus is on uSubscription service to ensure that a command is received in time. Below are the common retry and timeout policies for uSubscription service implementations to follow:   
 
 [.specitem,oft-sid="req~usubscription-remote-max-timeout~1",oft-needs="impl"]
 ****
@@ -524,7 +530,7 @@ Subscribe (and unsubscribe) to remote topics are handled by RPC calls between uS
 
 [.specitem,oft-sid="req~usubscription-remote-retry-indefinitely~1",oft-needs="impl"]
 ****
-- Timed-out remote commands *MUST* be retried indefinitely until the business logic behind it no longer requires the command to be sent (e.g. because the last entity unsubscribed from a topic that is in state `SUBSCRIPTION_PENDING`).
+- Timed-out remote commands *MUST* be retried indefinitely until the business logic behind it no longer requires the command to be sent (e.g. because the last entity unsubscribed from a topic with xref:subscription-status[SubscriptionStatus] `SUBSCRIPTION_PENDING`).
 ****
 
 [#reset-operation]
@@ -543,7 +549,7 @@ When a client invokes the uSubscription service's `Reset()` operation, uSubscrip
 
 1. clear all local and remote subscription state, including any associated persistence store
 2. clear the list of uEntities that have registered for subscription change notifications (via `RegisterForNotifications()`), including any associated persistence store
-3. send `Update` messages to each client subscribed to a topic or that has registered for notifications about a topic, with a subscription state of `UNSUBSCRIBED`
+3. send `Update` messages to each client subscribed to a topic or that has registered for notifications about a topic, with xref:subscription-status[SubscriptionStatus] `UNSUBSCRIBED`
 ****
 
 [.specitem,oft-sid="req~usubscription-reset-only-usubscription~1",oft-needs="impl,utest"]
@@ -560,29 +566,34 @@ Objects commonly used throughought this document are defined in this section.
 [#UURI]
 === UURI
 
-A UURI identifies resources in a uProtocol service mesh, and is defined in link:../../../basics/uri.adoc[the uProtocol URI specification].
+A UURI identifies resources in a uProtocol service mesh, and is defined in the uProtocol {uuri_ref} specification.
 
 [#topic-uuris]
 ==== Topic UURIs
 
 [.specitem,oft-sid="dsn~usubscription-valid-topic-uuris~1",oft-needs="impl,utest"]
-UURIs used to denote topics in uSubscription service API calls *MUST* adhere to the following rules, otherwise the API call will return a failure status message with {ucode_link} `INVALID_ARGUMENT`:
+The uSubscription service API *MUST* return a failure status message with {ucode_proto_ref} `INVALID_ARGUMENT` in case a topic UURI:
 
 * is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-// * contains a _wildcard_ resource ID,
+* contains an _empty_ or _wildcard_ `authority_name` or
+* contains a _wildcard_ _service ID_ (_least_ significant 16 bits of `ue_id`) or
+* contains a _wildcard_ `resource_id` or
+* contains a `resource_id` that is not within range `[0x8000, 0xFFFE]`
+
+It is permissible for topic UURIs to contain wildcard _service instance ID_ (_most_ significant 16 bits of `ue_id`). For example, imagine the case where a client wants to "subscribe to the _door open_ event, from any instance of _door_ in the vehicle".
 
 [#subscriber-uuris]
 ==== Subscriber UURIs
 
 [.specitem,oft-sid="dsn~usubscription-valid-subscriber-uuris~1",oft-needs="impl,utest"]
-UURIs used to denote subscribers in uSubscription service API calls *MUST* adhere to the following rules, otherwise the API call will return a failure status message with {ucode_link} `INVALID_ARGUMENT`:
+The uSubscription service API *MUST* return a failure status message with {ucode_proto_ref} `INVALID_ARGUMENT` in case a client UURI:
 
 * is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-* contains a _wildcard_ resource ID,
+* contains a _wildcard_ `authority_name` or
+* contains a _wildcard_ _service ID_ (_least_ significant 16 bits of `ue_id`) or
+* contains a _wildcard_ _service instance ID_ (most significant 16 bits of `ue_id`) or
+* contains an _empty_ or _wildcard_ `ue_version_major` or
+* contains a `resource_id` that is not `0`
 
 [#subscription-status]
 === SubscriptionStatus
@@ -590,81 +601,32 @@ UURIs used to denote subscribers in uSubscription service API calls *MUST* adher
 SubscriptionStatus is an enum-style object, describing the status of a subscriber-topic relationship.
 
 .SubscriptionStatus
-[cols="1,2,3"]
+[cols="1,3"]
 |===
-| Enum value | Name | Description
+|Name |Description
 
-| 0
-| UNSUBSCRIBED
-| Default state to indicate not subscribed
+| `UNSUBSCRIBED`
+| Default state, indicates no registered subscription
 
-| 1
-| SUBSCRIBE_PENDING 
+| `SUBSCRIBE_PENDING`
 | Subscription is pending confirmation from remote uSubscription service instance
 
-| 2
-| SUBSCRIBED
+| `SUBSCRIBED`
 | Subscription has been successful
 
-| 3
-| UNSUBSCRIBE_PENDING 
+| `UNSUBSCRIBE_PENDING`
 | Unsubscribe is pending confirmation from remote uSubscription service instance
 
 |=== 
 
 
-== uSubscription Sequences
+== Remote subscription sequences
 
-In the following section, we will elaborate on the various subscription flows for local and remote topics. When a consumer subscribes to a remote topic, it is the responsibility of the (local) uSubscription service to relay the subscription request to the remote uSubscription service as can be seen in the sequence diagrams below.
+In the following section, we will elaborate on subscription flows for remote topics. When a consumer subscribes to a remote topic, it is the responsibility of the (local) uSubscription service to relay the subscription request to the remote uSubscription service as can be seen in the sequence diagrams below.
 
-There are different types of messages passed between uEntities (_Request_/_Response_, _Publish_, _Notify_), this is how they are represented in the following sequence diagrams:
+=== Remote Subscribe
 
-[mermaid]
-ifdef::env-github[[source,mermaid]]
-----
-sequenceDiagram
-    participant App1
-    participant App2
-
-    rect rgb(245, 245, 245)
-    App1->>+App2: Request
-    App2-->>-App1: Response
-    end
-    rect rgb(230, 230, 230)
-    App1-)App2: Publish
-    end
-    rect rgb(215, 215, 215)
-    App1--)App2: Notify
-    end
-----
-
-=== Subscription
-
-Subscription flow will show how a subscriber can subscribe to a topic when uApp is on the same device (local subscriptions) or remote device (remote subscriptions).
-
-==== Within a uDevice
-
-.Local Subscription Flow
-[mermaid]
-ifdef::env-github[[source,mermaid]]
-----
-sequenceDiagram
-    box White Device1
-        actor uApp
-        participant uSubscription
-    end
-
-    uApp->>+uSubscription: Subscribe(SubscriptionRequest)   
-
-    alt success
-        uSubscription-->>uApp: SubscriptionResponse(SUBSCRIBED)
-        uSubscription--)uApp: Update(SUBSCRIBED)
-    else failure
-        uSubscription-->>-uApp: SubscriptionResponse(UNSUBSCRIBED)
-    end
-----
-
-==== Between uDevices
+This sequence diagram shows how a client subscribes to a topic that is published on a remote device (remote subscription).
 
 .Remote Subscription Flow
 [mermaid]
@@ -672,60 +634,40 @@ ifdef::env-github[[source,mermaid]]
 ----
 sequenceDiagram
     box White Device1
-        actor uApp
+        actor Client
         participant local uSubscription
     end
     box White Device2
         participant remote uSubscription
         participant uEntity
     end
-    
+
     uEntity->>+remote uSubscription: RegisterForNotification()
-    uApp->>+local uSubscription: Subscribe(SubscriptionRequest)
+    Client->>+local uSubscription: Subscribe(SubscriptionRequest)
 
     alt first subscription
-        local uSubscription-->>uApp: SubscriptionResponse(SUBSCRIPTION_PENDING)
+        local uSubscription-->>Client: SubscriptionResponse(SUBSCRIPTION_PENDING)
         local uSubscription-->>remote uSubscription: Subscribe(SubscriptionRequest)
         alt success
             remote uSubscription-->>local uSubscription: SubscriptionResponse(SUBSCRIBED)
             remote uSubscription--)uEntity: Update(SUBSCRIBED)
-            
-            local uSubscription--)uApp: Update(SUBSCRIBED)
+
+            local uSubscription--)Client: Update(SUBSCRIBED)
         else failure
             remote uSubscription-->>local uSubscription: SubscriptionResponse(UNSUBSCRIBED)
 
-            local uSubscription-->>uApp: Update(UNSUBSCRIBED)
+            local uSubscription-->>Client: Update(UNSUBSCRIBED)
         end
     else follow-on subscription
-        local uSubscription-->>uApp: SubscriptionResponse(SUBSCRIBED)
-        local uSubscription--)uApp: Update(SUBSCRIBED)    
+        local uSubscription-->>Client: SubscriptionResponse(SUBSCRIBED)
+        local uSubscription--)Client: Update(SUBSCRIBED)    
     end
     uEntity->>+remote uSubscription: UnregisterForNotification()
 ----
 
 To allow the reverse flow (publication) to be properly multicast to local subscribers by the local disaptcher when it queries the local uSubscription for a list of local subscribers, remote subscriptions are always performed between uSubscription services using their own uEntity identifiers (`core.usubscription`). 
 
-=== Unsubscribe
-
-==== Within a uDevice
-
-.Local Unsubscribe Flow
-[mermaid]
-ifdef::env-github[[source,mermaid]]
-----
-sequenceDiagram
-    box White Device1
-        actor uApp
-        participant uSubscription
-    end
-
-    uApp->>+uSubscription: Unsubscribe(UnsubscribeRequest)   
-
-    uSubscription-->>uApp: Ok
-    uSubscription--)uApp: Update(UNSUBSCRIBED)
-----
-
-==== Between uDevices
+=== Remote Unsubscribe
 
 .Remote Unsubscribe Flow
 [mermaid]
@@ -733,7 +675,7 @@ ifdef::env-github[[source,mermaid]]
 ----
 sequenceDiagram
     box White Device1
-        actor uApp
+        actor Client
         participant local uSubscription
     end
     box White Device2
@@ -742,12 +684,12 @@ sequenceDiagram
     end
     
     uEntity->>+remote uSubscription: RegisterForNotification()
-    uApp->>+local uSubscription: Unsubscribe(UnsubscribeRequest)
+    Client->>+local uSubscription: Unsubscribe(UnsubscribeRequest)
     alt success
-        local uSubscription-->>uApp: Ok
-        local uSubscription--)uApp: Update(UNSUBSCRIBED)
+        local uSubscription-->>Client: Ok
+        local uSubscription--)Client: Update(UNSUBSCRIBED)
     else failure
-        local uSubscription-->>uApp: Failure
+        local uSubscription-->>Client: Failure
     end
 
     opt last subscription

--- a/up-l3/usubscription/v3/README.adoc
+++ b/up-l3/usubscription/v3/README.adoc
@@ -3,8 +3,8 @@
 :sectnums:
 :usubscription_proto_link: link:../../../up-core-api/uprotocol/core/usubscription/v3/usubscription.proto[usubscription.proto]
 :communication_layer_api_ref: xref:../../../up-l2/api.adoc[Communication Layer API] 
-:uuri_ref: xref:../../../basics/uri.adoc[uProtocol URI]
-:ucode_link: link:../../../up-core-api/uprotocol/v1/ucode.proto[`UCode`]
+:uuri_ref: xref:../../../basics/uri.adoc[UURI]
+:ucode_ref: link:../../../up-core-api/uprotocol/v1/ucode.proto[UCode]
 
 The key words "*MUST*", "*MUST NOT*", "*REQUIRED*", "*SHALL*", "*SHALL NOT*", "*SHOULD*", "*SHOULD NOT*", "*RECOMMENDED*", "*MAY*", and "*OPTIONAL*" in this document are to be interpreted as described in https://www.rfc-editor.org/info/bcp14[IETF BCP14 (RFC2119 & RFC8174)]
 
@@ -42,6 +42,11 @@ A distributed publish-subscribe network requires the following capabilities to b
 
 The remainder of this document defines the use cases, interfaces, state machines and application flows to support cross-system tracking of subscriptions, especially to/from remote systems.
 
+[.specitem,oft-sid="dsn~usubscription-service_name~1",oft-needs="impl,utest"]
+The uSubscription service name *MUST* be `core.usubscription`.
+
+NOTE: The UCode and UUri classes are defined in detail in {ucode_ref} and uProtocol {uuri_ref} specifications.
+
 [#usubscription-local-remote-subscriptions]
 == Local and Remote Subscriptions
 
@@ -68,143 +73,232 @@ A Publisher in a uProtocol network usually does not perform any additional actio
 A _Subscriber_ is a uEntity that is interested in a particular _topic_ and wants to receive messages that have been published to that topic by other uEntities. Subscribers typically use the {communication_layer_api_ref} for this purpose.
 
 [.specitem,oft-sid="dsn~usubscription-interaction-subscriber~1"]
-****
-In addition to performing the actions necessary to subscribe to and receive messages from the transport that they are using, Subscribers in a uProtocol network *MUST* invoke the <<subscribe-operation>> and <<unsubscribe-operation>> operations of their local uSubscription service instance in order to indicate which topics they _subscribe_ to or _unsubscribe_ from.
-****
+In addition to performing the actions necessary to subscribe to and receive messages from the transport that they are using, Subscribers in a uProtocol network are *REQUIRED* to invoke the <<subscribe-operation>> and <<unsubscribe-operation>> operations of their local uSubscription service instance in order to indicate which topics they _subscribe_ to or _unsubscribe_ from.
 
 [#subscribe-operation]
 === Subscribe()
 
-[.specitem,oft-sid="dsn~usubscription-subscribe-protobuf~1",oft-needs="impl,utest"]
-****
-The uSubscription service `Subscribe()` function *MUST* implement the corresponding protobuf definition in {usubscription_proto_link}.
-****
+// [.specitem,oft-sid="dsn~usubscription-subscribe-protobuf~1",oft-needs="impl,utest"]
+// The uSubscription service `Subscribe()` function *MUST* implement the corresponding protobuf definition in {usubscription_proto_link}.
+
+Register the calling client as subscriber to a topic. 
+
+* Returns the status of the requested subscription. 
+* Calling this endpoint also registers the subscribing client to receive subscription change notifications when the subscription status changes.
+
+[.specitem,oft-sid="dsn~usubscription-subscribe-method_id~1",oft-needs="impl,utest"]
+The uSubscription service `Subscribe()` function *MUST* use the method ID 1.
+
+[.specitem,oft-sid="req~usubscription-subscribe-signature~1",oft-needs="dsn,impl,utest"]
+The uSubscription service `Subscribe()` function *MUST* implement the following message definitions:
+
+.Subscribe() function request parameters
+[#subscribe-request-data-model]
+[mermaid]
+ifdef::env-github[[source,mermaid]]
+----
+classDiagram
+class Subscribe {
+        <<Interface>>
+}
+
+class SubscribeRequest {
+    <<UMessage>>
+    topic : UURI
+    expiry : UInt64[0..1]
+    sample-period : UInt32[0..1]
+}
+class SubscribeResponse {
+    <<UMessage>>
+    topic : UURI
+    status : SubscriptionStatus
+}
+
+Subscribe ..> SubscribeRequest : request message
+Subscribe ..> SubscribeResponse : response message
+----
+
+---
+
+The following table provides detailed descriptions of the SubscribeRequest attributes:
+
+[%autowidth]
+|===
+|Name |Type |Mandatory |Description
+
+|`topic`
+|{uuri_ref}
+|yes
+a|
+--
+uProtocol URI of the topic to subscribe to.
+
+Also refer to xref:topic-uuris[Topic UURIs] regarding specific restrictions on topic UURIs.
+--
+
+|`expiry`
+|UInt64
+|no
+a|
+[.specitem,oft-sid="dsn~usubscription-subscribe-past_expiry~1",oft-needs="impl,utest",oft-tags="uSubscription"]
+--
+Define when the subscription should expire, in millisecond granularity (timestamp should be set in the future).
+
+* If this field is missing, the subscription is assumed to remain valid indefinitely.
+* If the timestamp is set in the past when evaluated by uSubscription service, it *MUST NOT* register the subscription and return `UNSUBSCRIBED` as subscription status.
+--
+
+|`sample-period`
+|UInt32
+|no
+a|
+--
+Desired sampling period (in milliseconds) the subscriber wishes to receive
+events in, applicable only for remote topics. Device dispatchers (i.e. streamers) use
+this attribute to reduce the publication rate of messages sent between devices.
+This attribute is might e.g. be used by mobile/cloud clients subscribing to in-vehicle 
+topics that in their original scope are published at a high rate.
+
+* If the desired sampling period is lower than the original publisher's publication period, the attribute is ignored.
+* If this attribute is missing, the sampling period is chosen by the publisher.
+--
+
+|===
+
+---
+
+The following table provides detailed description of the SubscribeResponse attributes:
+
+[%autowidth]
+|===
+|Name |Type |Description
+
+|`topic`
+|{uuri_ref}
+a|
+--
+Subscribed topic, as passed to SubscriptionRequest
+--
+
+|`status`
+|xref:SubscriptionStatus[SubscriptionStatus]
+a|
+--
+Current status of the subscription.
+--
+
+|===
+
+---
 
 [.specitem,oft-sid="req~usubscription-subscribe~1",oft-needs="impl,utest"]
-****
 When a client calls the `Subscribe()` function, uSubscription service *MUST* start tracking the client as a subscriber to the topic provided with the function call.
-****
 
 [.specitem,oft-sid="req~usubscription-subscribe-persistency~1",oft-needs="impl,utest"]
-****
 When a client calls the `Subscribe()` function, uSubscription service *MUST* persistenly (across service restarts) store the client as a subscriber of the provided topic.
-****
 
 [.specitem,oft-sid="req~usubscription-subscribe-expiration~1",oft-needs="impl,utest"]
-****
-When the subscription expiration time (defined in the `expire` field of `SubscriptionRequest.attributes`) is exceeded, uSubscription service *MUST* stop tracking the associated client-topic subscription.
-****
+When the subscription expiration time is exceeded, uSubscription service *MUST* stop tracking the associated client-topic subscription.
 
 [.specitem,oft-sid="req~usubscription-subscribe-no-expiration~1",oft-needs="impl,utest"]
-****
 When a subscription request does not specify an expiration time, uSubscription service *MUST* track the associated client-topic subscription indefinitely and persistently (across service restarts).
-****
 
 [.specitem,oft-sid="req~usubscription-subscribe-multiple~1",oft-needs="impl,utest"]
-****
 When a client calls the `Subscribe()` function for a topic that it is already subscribed to, uSubscription service *MUST* return a response message containing the current subscription status for this client-topic combination (e.g. `SUBSCRIBED` or `SUBSCRIBE_PENDING`).
-****
 
 [.specitem,oft-sid="req~usubscription-subscribe-expiration-extension~1",oft-needs="impl,utest"]
-****
-When a client calls the `Subscribe()` function for a topic that it is already subscribed to where the value in the `expire` field of `SubscriptionRequest.attributes` differs from the current expiration time, uSubscription service *MUST* update the expiration time of the subscription with the new value.
-****
+When a client calls the `Subscribe()` function for a topic that it is already subscribed to where the `expire` field value differs from the current expiration time, uSubscription service *MUST* update the expiration time of the subscription with the new value.
 
 [.specitem,oft-sid="req~usubscription-subscribe-remote~1",oft-needs="impl,utest"]
-****
 When a client makes the first call to `Subscribe()` to a _remote_ topic, i.e. a topic that is not published by a uEntity on the local host, uSubscription service *MUST* establish a remote subscription to that topic by sending a `Subscribe()` request to the (remote) uSubscription service running on the host indicated by the remote topic's _authority_. 
-****
-
-[.specitem,oft-sid="dsn~usubscription-subscribe-remote-subscriber-change~1",oft-needs="impl,utest"]
-****
-uSubscription service *MUST* change the subscriber field to itself (`core.usubscription`) when sending a `Subscribe()` request to a remote uSubscription service. 
-****
 
 [.specitem,oft-sid="req~usubscription-subscribe-remote-pending~1",oft-needs="impl,utest"]
-****
 When uSubscription service sends a `Subscribe()` request to a remote uSubscription service, uSubscription service *MUST* set the subscription state for any client-topic combination involving the subscribed remote topic to `SUBSCRIBE_PENDING`.
-****
 
 [.specitem,oft-sid="req~usubscription-subscribe-remote-response~1",oft-needs="impl,utest"]
-****
 When uSubscription service receives a reply to a remote `Subscribe()` request, uSubscription service *MUST* set the subscription state for any client-topic combination involving the subscribed remote topic to match the subscription status response of the remote uSubscription service (e.g. `SUBSCRIBED` or `UNSUBSCRIBED`).
-****
 
 [.specitem,oft-sid="req~usubscription-subscribe-unsubscribe-pending~1",oft-needs="impl,utest"]
-****
 When a client calls the `Subscribe()` function for a remote topic that is in state `UNSUBSCRIBE_PENDING`, uSubscription service *MUST* initiate the regular remote subscription process, i.e. send a subscription request to the remote uSubscription service and set status to `SUBSCRIBE_PENDING`.
-****
 
 [.specitem,oft-sid="req~usubscription-subscribe-notifications~1",oft-needs="impl,utest"]
-****
 When a client calls the `Subscribe()` function, uSubscription service *MUST* generate subscription change notifications reflecting any changes to the subscription state of the subscribed topic.
-****
-
-[.specitem,oft-sid="dsn~usubscription-subscribe-invalid-topic~1",oft-needs="impl,utest"]
-****
-When receiving a `Subscribe()` request that contains a topic that
-* is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-* contains a _wildcard_ resource ID,
-
-a uSubscription service *MUST* return a failure status message with {ucode_link} `INVALID_ARGUMENT`.
-****
 
 [#unsubscribe-operation]
 === Unsubscribe()
 
-[.specitem,oft-sid="dsn~usubscription-unsubscribe-protobuf~1",oft-needs="impl,utest"]
-****
-The uSubscription service `Unsubscribe()` function *MUST* implement the corresponding protobuf definition in {usubscription_proto_link}.
-****
+Unregister the calling client as subscriber to a topic. 
+
+* Always succeeds from the client's point of view; uSubscription service will set the subscription status to 'UNSUBSCRIBED' upon receiving an Unsubscribe() request.
+* Calling this endpoint unregisters the client from receive subscription change notifications when the subscription status changes.
+
+// [.specitem,oft-sid="dsn~usubscription-unsubscribe-protobuf~1",oft-needs="impl,utest"]
+// The uSubscription service `Unsubscribe()` function *MUST* implement the corresponding protobuf definition in {usubscription_proto_link}.
+
+[.specitem,oft-sid="dsn~usubscription-unsubscribe-method_id~1",oft-needs="impl,utest"]
+The uSubscription service `Subscribe()` function *MUST* use the method ID 2.
+
+[.specitem,oft-sid="req~usubscription-unsubscribe-signature~1",oft-needs="dsn,impl,utest"]
+The uSubscription service `Unsubscribe()` function *MUST* implement the following message definitions:
+
+.Unsubscribe() function request parameters
+[#unsubscribe-data-model]
+[mermaid]
+ifdef::env-github[[source,mermaid]]
+----
+classDiagram
+class Unsubscribe {
+        <<Interface>>
+}
+
+class UnsubscribeRequest {
+    <<UMessage>>
+    topic : UURI
+}
+class UnsubscribeResponse {
+    <<UMessage>>
+}
+
+Unsubscribe ..> UnsubscribeRequest : request message
+Unsubscribe ..> UnsubscribeResponse : response message
+----
+
+---
+
+The following table provides detailed description of the UnsubscribeRequest attributes:
+
+[%autowidth]
+|===
+|Name |Type |Mandatory |Description
+
+|`topic`
+|{uuri_ref}
+|yes
+a|
+--
+uProtocol URI of the topic to unsubscribe from.
+
+Also refer to xref:topic-uuris[Topic UURIs] regarding specific restrictions on topic UURIs.
+--
+
+|===
+
+---
 
 [.specitem,oft-sid="req~usubscription-unsubscribe~1",oft-needs="impl,utest"]
-****
 When a client calls the `Unsubscribe()` function, uSubscription service *MUST* stop tracking the client as a subscriber to the topic provided with the function call.
-****
-
-[.specitem,oft-sid="req~usubscription-unsubscribe-multiple~1",oft-needs="impl,utest"]
-****
-When a client calls the `Unsubscribe()` function for a topic that it has not subscribed to, uSubscription service *MUST* return a response message containing the subscription status `UNSUBSCRIBED`.
-****
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-last-remote~1",oft-needs="impl,utest"]
-****
 When the last client subscribed to a remote topic calls the `Unsubscribe()` function on that topic, uSubscription service *MUST* perform a remote unsubscribe on that topic by sending an `Unsubscribe()` request to the remote uSubscription service. 
-****
-
-[.specitem,oft-sid="dsn~usubscription-unsubscribe-remote-subscriber-change~1",oft-needs="impl,utest"]
-****
-uSubscription service *MUST* change the subscriber field to itself (`core.usubscription`) when sending an `Unsubscribe()` request to a remote uSubscription service. 
-****
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-remote-unsubscribed~1",oft-needs="impl,utest"]
-****
 When sending an `Unsubscribe()` request to a remote uSubscription service, uSubscription service *MUST* consider the remote topic to be in state `UNSUBSCRIBED`, regardless of the status returned from the remote uSubscription service.
-****
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-subscribe-pending~1",oft-needs="impl,utest"]
-****
 When a client calls the `Unsubscribe()` function for a remote topic that is in state `SUBSCRIBE_PENDING`, uSubscription service *MUST* initiate the regular remote unsubscribe process, i.e. send an unsubscribe request to the remote uSubscription service and set status to `UNSUBSCRIBED`.
-****
 
 [.specitem,oft-sid="req~usubscription-unsubscribe-notifications~1",oft-needs="impl,utest"]
-****
 When the last client subscribed to a topic calls the `Unsubscribe()` function on that topic, uSubscription service *MUST* stop generating subscription change notifications for that topic.
-****
-
-[.specitem,oft-sid="dsn~usubscription-unsubscribe-invalid-topic~1",oft-needs="impl,utest"]
-****
-When receiving a `Unsubscribe()` request that contains a topic that
-
-* is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-* contains a _wildcard_ resource ID,
-
-a uSubscription service *MUST* return a failure status message with {ucode_link} `INVALID_ARGUMENT`.
-****
 
 [#fetch-subscribers-operation]
 === FetchSubscribers()
@@ -217,18 +311,6 @@ The uSubscription service `FetchSubscribers()` function *MUST* implement the cor
 [.specitem,oft-sid="req~usubscription-fetch-subscribers~1",oft-needs="impl,utest"]
 ****
 When a client calls the `FetchSubscribers()` function, uSubscription service *MUST* return a list of subscribers that are currently subscribed to a given topic.
-****
-
-[.specitem,oft-sid="dsn~usubscription-fetch-subscribers-invalid-topic~1",oft-needs="impl,utest"]
-****
-When receiving a `FetchSubscribers()` request that contains a topic that
-
-* is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-* contains a _wildcard_ resource ID,
-
-a uSubscription service *MUST* return a failure status message with {ucode_link} `INVALID_ARGUMENT`.
 ****
 
 [#fetch-subscriptions-operation]
@@ -247,29 +329,6 @@ When a client calls the `FetchSubscriptions()` function with a `SubscriberInfo` 
 [.specitem,oft-sid="req~usubscription-fetch-subscriptions-by-topic~1",oft-needs="impl,utest"]
 ****
 When a client calls the `FetchSubscriptions()` function with a topic UURI argument, uSubscription service *MUST* return a list of subscribers that are currently subscribed to the given topic.
-****
-
-[.specitem,oft-sid="dsn~usubscription-fetch-subscriptions-invalid-topic~1",oft-needs="impl,utest"]
-****
-When receiving a `FetchSubscriptions()` request that contains a topic that
-
-* is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-* contains a _wildcard_ resource ID,
-
-a uSubscription service *MUST* return a failure status message with {ucode_link} `INVALID_ARGUMENT`.
-****
-
-[.specitem,oft-sid="dsn~usubscription-fetch-subscriptions-invalid-subscriber~1",oft-needs="impl,utest"]
-****
-When receiving a `FetchSubscriptions()` request that contains a subscriber URI that
-* is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-* contains a _wildcard_ resource ID,
-
-a uSubscription service *MUST* return a failure status message with {ucode_link} `INVALID_ARGUMENT`.
 ****
 
 [#usubscription-topic]
@@ -401,18 +460,6 @@ The uSubscription service `RegisterForNotifications()` function *MUST* implement
 uSubscription service *MUST* send subscription change notification messages to clients that have previously called `RegisterForNotifications()` to _opt-in_ to receive notifications for a specific topic specified in `NotificationsRequest.topic` field. 
 ****
 
-[.specitem,oft-sid="dsn~usubscription-register-notifications-invalid-topic~1",oft-needs="impl,utest"]
-****
-When receiving a `RegisterForNotifications()` request that contains a topic that
-
-* is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-* contains a _wildcard_ resource ID,
-
-a uSubscription service *MUST* return a failure status message with {ucode_link} `INVALID_ARGUMENT`.
-****
-
 [#unregister-for-notifications-operation]
 ==== UnregisterForNotifications()
 
@@ -424,18 +471,6 @@ The uSubscription service `UnregisterForNotifications()` function *MUST* impleme
 [.specitem,oft-sid="req~usubscription-unregister-notifications~1",oft-needs="impl,utest"]
 ****
 uSubscription service *MUST* stop sending subscription change notifications to clients afther they have _opted-out_ of receiving subscription change notification by calling `UnregisterForNotifications()`. 
-****
-
-[.specitem,oft-sid="dsn~usubscription-unregister-notifications-invalid-topic~1",oft-needs="impl,utest"]
-****
-When receiving a `UnregisterForNotifications()` request that contains a topic that
-
-* is not a valid {uuri_ref} or
-* contains a _wildcard_ authority or
-* contains a _wildcard_ uEntity ID (`ue_id`) or
-* contains a _wildcard_ resource ID,
-
-a uSubscription service *MUST* return a failure status message with {ucode_link} `INVALID_ARGUMENT`.
 ****
 
 == Timeout & Retry Logic
@@ -475,6 +510,68 @@ When a client invokes the uSubscription service's `Reset()` operation, uSubscrip
 ****
 When receiving a `Reset()` call from a source that is not another uSubscription services (i.e. from source URIs where uEntity ID (`ue_id`) does not equal _0x0_), uSubscription service *MUST* return a failure status message with {ucode_link} `PERMISSION_DENIED`.
 ****
+
+[#common-objects]
+== Common Objects
+
+Objects commonly used throughought this document are defined in this section.
+
+
+[#UURI]
+=== UURI
+
+A UURI identifies resources in a uProtocol service mesh, and is defined in link:../../../basics/uri.adoc[the uProtocol URI specification].
+
+[#topic-uuris]
+==== Topic UURIs
+
+[.specitem,oft-sid="dsn~usubscription-valid-topic-uuris~1",oft-needs="impl,utest"]
+UURIs used to denote topics in uSubscription service API calls *MUST* adhere to the following rules, otherwise the API call will return a failure status message with {ucode_link} `INVALID_ARGUMENT`:
+
+* is not a valid {uuri_ref} or
+* contains a _wildcard_ authority or
+* contains a _wildcard_ uEntity ID (`ue_id`) or
+// * contains a _wildcard_ resource ID,
+
+[#subscriber-uuris]
+==== Subscriber UURIs
+
+[.specitem,oft-sid="dsn~usubscription-valid-subscriber-uuris~1",oft-needs="impl,utest"]
+UURIs used to denote subscribers in uSubscription service API calls *MUST* adhere to the following rules, otherwise the API call will return a failure status message with {ucode_link} `INVALID_ARGUMENT`:
+
+* is not a valid {uuri_ref} or
+* contains a _wildcard_ authority or
+* contains a _wildcard_ uEntity ID (`ue_id`) or
+* contains a _wildcard_ resource ID,
+
+[#subscription-status]
+=== SubscriptionStatus
+
+SubscriptionStatus is an enum-style object, describing the status of a subscriber-topic relationship.
+
+.SubscriptionStatus
+[cols="1,2,3"]
+|===
+| Enum value | Name | Description
+
+| 0
+| UNSUBSCRIBED
+| Default state to indicate not subscribed
+
+| 1
+| SUBSCRIBE_PENDING 
+| Subscription is pending confirmation from remote uSubscription service instance
+
+| 2
+| SUBSCRIBED
+| Subscription has been successful
+
+| 3
+| UNSUBSCRIBE_PENDING 
+| Unsubscribe is pending confirmation from remote uSubscription service instance
+
+|=== 
+
 
 == uSubscription Sequences
 


### PR DESCRIPTION
Update, improve and cleanup comments and documentation of usubscription.proto

This is a complete once-over of almost every doc-string in the usubscription protobuf definition, and the first part of the work to address #321 