### PR TITLE
feat: open payload-encoding identity on UAttributes

### DIFF
--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -183,6 +183,21 @@ a|The format of the payload (data).
 [.specitem,oft-sid="dsn~up-attributes-payload-format~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
 --
 * *MUST NOT* contain a value if the message has no payload.
+* For a payload-bearing message, `payloadFormat` *MUST* be used only for legacy-compatible encodings in the UFrame payload-encoding registry range `1..=8`.
+--
+
+|`payloadEncodingRegistryId`, `payloadEncoding`, `payloadContentType`
+|`UInt32`, `String`, `String`
+|no
+a|Open payload-encoding identity components for payload encodings that have no `UPayloadFormat` equivalent.
+
+[.specitem,oft-sid="dsn~up-attributes-open-payload-encoding~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
+--
+* These fields *MUST NOT* contain values if the message has no payload.
+* For a payload-bearing message using an open payload encoding, at least one of these fields *MUST* be present.
+* A payload-bearing message *MUST* populate exactly one encoding mechanism: either `payloadFormat` or these open payload-encoding fields, never both.
+* Encodings in the UFrame payload-encoding registry range `1..=8` *MUST* use `payloadFormat` and *MUST NOT* be represented by these open fields.
+* A receiver that does not understand an open payload-encoding identity *MUST* reject the payload as not decodable by that receiver and *MUST NOT* reinterpret it as raw bytes.
 --
 
 |===

--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -63,7 +63,24 @@ message UAttributes {
     optional string traceparent = 11;
 
     // The format for the data stored in the UMessage.
+    //
+    // Covers the legacy-compatible numeric range of the UFrame payload-encoding
+    // registry. Payload encodings outside that range are carried by the open
+    // payload-encoding identity fields below. A payload-bearing message MUST
+    // populate exactly one encoding mechanism.
     UPayloadFormat payload_format = 12;
+
+    // Optional numeric registry id from the UFrame payload-encoding registry
+    // for encodings that have no UPayloadFormat equivalent.
+    optional uint32 payload_encoding_registry_id = 13;
+
+    // Optional literal id from the UFrame payload-encoding registry for
+    // encodings that have no UPayloadFormat equivalent.
+    optional string payload_encoding = 14;
+
+    // Optional media type from the UFrame payload-encoding registry for
+    // encodings that have no UPayloadFormat equivalent.
+    optional string payload_content_type = 15;
 }
 
 
@@ -127,6 +144,13 @@ enum UPriority {
 }
 
 // The format for the data stored in the UMessage.
+//
+// Values 1..=8 are permanently reserved as the legacy-compatible numeric
+// range for UFrame payload-encoding registry ids. New UFrame-native encodings
+// are registered in the open UFrame payload-encoding registry instead of being
+// added to this enum. A UFrame semantic metadata model MUST NOT embed
+// UPayloadFormat; this enum is a legacy projection surface for UMessage and
+// UAttributes compatibility.
 enum UPayloadFormat {
     // Payload format is unknown.
     UPAYLOAD_FORMAT_UNSPECIFIED = 0;


### PR DESCRIPTION
Adds three optional fields to UAttributes for payload encodings that have no UPayloadFormat equivalent:

  optional uint32 payload_encoding_registry_id = 13;
  optional string payload_encoding                      = 14;
  optional string payload_content_type               = 15;

Motivation: UPayloadFormat is a closed enum. Every new payload encoding (a CDR profile, an Arrow layout, a custom vehicle-domain codec) currently requires editing the enum in the core proto, which churns the wire contract and every implementation. These fields carry an open encoding identity instead: a registered numeric id, a literal id, or a media type, individually or together.

Contract (normative text in basics/uattributes.adoc):
- payload-free messages carry none of these;
- a payload-bearing message populates exactly one encoding mechanism, legacy payloadFormat or the open identity, never both;
- UPayloadFormat values 1..=8 are permanently reserved as the legacy-compatible numeric range and are never re-registered as open identities, so the two mechanisms can never alias;
- a receiver that does not understand an open identity rejects the payload rather than reinterpreting it as raw bytes.

The change is wire-compatible: fields are optional, field numbers 13-15 were unused, existing messages are unaffected, and the enum is untouched. A follow-up specification for the frame-native metadata model builds on these fields; they stand alone as an extensibility mechanism regardless.