### PR TITLE
Proto enum defaultvalue

### DIFF
--- a/up-core-api/uprotocol/core/usubscription/v4/usubscription.proto
+++ b/up-core-api/uprotocol/core/usubscription/v4/usubscription.proto
@@ -27,6 +27,7 @@ option java_multiple_files = true;
 option cc_generic_services = true;
 
 enum SubscriptionStatus {
+  // not required by the spec, but recommended by protobuf programming guide (https://protobuf.dev/programming-guides/proto3/#enum)
   UNSPECIFIED = 0;
   UNSUBSCRIBED = 1;
   SUBSCRIBE_PENDING = 2;

--- a/up-core-api/uprotocol/core/usubscription/v4/usubscription.proto
+++ b/up-core-api/uprotocol/core/usubscription/v4/usubscription.proto
@@ -27,10 +27,11 @@ option java_multiple_files = true;
 option cc_generic_services = true;
 
 enum SubscriptionStatus {
-  UNSUBSCRIBED = 0;
-  SUBSCRIBE_PENDING = 1;
-  SUBSCRIBED = 2;
-  UNSUBSCRIBE_PENDING = 3;
+  UNSPECIFIED = 0;
+  UNSUBSCRIBED = 1;
+  SUBSCRIBE_PENDING = 2;
+  SUBSCRIBED = 3;
+  UNSUBSCRIBE_PENDING = 4;
 }
 
 // [dsn->req~usubscription-change-message-type~1>>impl]

--- a/up-core-api/uprotocol/core/usubscription/v4/usubscription.proto
+++ b/up-core-api/uprotocol/core/usubscription/v4/usubscription.proto
@@ -28,11 +28,11 @@ option cc_generic_services = true;
 
 enum SubscriptionStatus {
   // not required by the spec, but recommended by protobuf programming guide (https://protobuf.dev/programming-guides/proto3/#enum)
-  UNSPECIFIED = 0;
-  UNSUBSCRIBED = 1;
-  SUBSCRIBE_PENDING = 2;
-  SUBSCRIBED = 3;
-  UNSUBSCRIBE_PENDING = 4;
+  STATUS_UNSPECIFIED = 0;
+  STATUS_UNSUBSCRIBED = 1;
+  STATUS_SUBSCRIBE_PENDING = 2;
+  STATUS_SUBSCRIBED = 3;
+  STATUS_UNSUBSCRIBE_PENDING = 4;
 }
 
 // [dsn->req~usubscription-change-message-type~1>>impl]


### PR DESCRIPTION
Add protobuf enum default value (`UNSPECIFIED`), according to protobuf programming guide: https://protobuf.dev/programming-guides/proto3/#enum