### PR TITLE
[#328] Make `commstatus` mandatory for RPC Response messages

### DIFF
--- a/basics/error_model.adoc
+++ b/basics/error_model.adoc
@@ -103,7 +103,7 @@ A service consumer invoking this operation will then receive a `UMessage` with a
 
 == Service Provider Implementation
 
-[.specitem,oft-sid="dsn~service-error-model-success-response~1",oft-needs="impl,utest",oft-tags="ServiceProvider"]
+[.specitem,oft-sid="dsn~service-error-model-success-response~2",oft-needs="impl,utest",oft-tags="ServiceProvider"]
 --
 In case of _successful_ execution of a service operation, a service provider
 

--- a/basics/error_model.adoc
+++ b/basics/error_model.adoc
@@ -41,36 +41,36 @@ classDiagram
 
 class UStatus {
   message: String[0..1]
-  details: Object[*]
+  details: Object[0..*]
 }
 
 class UCode {
   <<Enumeration>>
-  OK
-  CANCELLED
-  UNKNOWN
-  INVALID_ARGUMENT
-  DEADLINE_EXCEEDED
-  NOT_FOUND
-  ALREADY_EXISTS
-  PERMISSION_DENIED
-  UNAUTHENTICATED
-  RESOURCE_EXHAUSTED
-  FAILED_PRECONDITION
-  ABORTED
-  OUT_OF_RANGE
-  UNIMPLEMENTED
-  INTERNAL
-  UNAVAILABLE
-  DATA_LOSS
+  Ok
+  Cancelled
+  Unknown
+  InvalidArgument
+  DeadlineExceeded
+  NotFound
+  AlreadyExists
+  PermissionDenied
+  Unauthenticated
+  ResourceExhausted
+  FailedPrecondition
+  Aborted
+  OutOfRange
+  Unimplemented
+  Internal
+  Unavailable
+  DataLoss
 }
 
-UStatus--> "0..1" UCode : code
+UStatus o-- UCode : code
 ----
 
 Each xref:../languages.adoc[uProtocol Language Library]
 
-[.specitem,oft-sid="req~ustatus-data-model-impl~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
+[.specitem,oft-sid="req~ustatus-data-model-impl~2",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
 --
 * *MUST* implement the <<ustatus-data-model>> using the language specific type system.
 --
@@ -108,14 +108,14 @@ A service consumer invoking this operation will then receive a `UMessage` with a
 In case of _successful_ execution of a service operation, a service provider
 
 * *MUST* put the operation's response Protobuf Message into the response xref:umessage.adoc[`UMessage`]'s `payload`
-* *MAY* set the response message's `commstatus` attribute to value `UCode.OK` to indicate successful execution. If the `commstatus` attribute is not set, it is assumed to be `UCode.OK`.
+* *MUST* set the response message's `commstatus` attribute to value `UCode.Ok` to indicate successful execution.
 --
 
 [.specitem,oft-sid="dsn~service-error-model-error-response~1",oft-needs="impl,utest",oft-tags="ServiceProvider"]
 --
 In case of _erroneous_ execution, a service provider
 
-* *MUST* set the `commstatus` attribute of the response xref:umessage.adoc[`UMessage`] to the <<ustatus-data-model,UCode>> value other than `UCode.OK` which most closely matches the reason for failure.
+* *MUST* set the `commstatus` attribute of the response xref:umessage.adoc[`UMessage`] to the <<ustatus-data-model,UCode>> value other than `UCode.Ok` which most closely matches the reason for failure.
 * *SHOULD* populate the response xref:umessage.adoc[`UMessage`] `payload` with a <<ustatus-data-model,UStatus>> that contains additional failure information (e.g. message, details). The `code` property value of the `UStatus` in the payload *MUST* be the same as the value of the response message's `commstatus` attribute.
 --
 
@@ -123,6 +123,6 @@ In case of _erroneous_ execution, a service provider
 
 [.specitem,oft-sid="dsn~service-error-model-failed-rpc~1",oft-needs="impl,utest",oft-tags="ServiceConsumer"]
 --
-A service consumer *MUST* consider an RPC as _failed_, if the `commstatus` property contained in the xref:uattributes.adoc#response-attributes[response message attributes] has a value other than `UCode.OK`.
+A service consumer *MUST* consider an RPC as _failed_, if the `commstatus` property contained in the xref:uattributes.adoc#response-attributes[response message attributes] has a value other than `UCode.Ok`.
 In that case, the consumer *SHOULD* try to extract a <<ustatus-data-model,UStatus>> from the response message's payload and make it available to application code.
 --

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -81,9 +81,9 @@ class UPayloadFormat {
   UPAYLOAD_FORMAT_SHM
 }
 
-UAttributes-->UMessageType : type
-UAttributes--> "0..1" UPriority : priority
-UAttributes--> "0..1" UPayloadFormat : payloadFormat
+UAttributes --> UMessageType : type
+UAttributes --> "0..1" UPriority : priority
+UAttributes --> "0..1" UPayloadFormat : payloadFormat
 ----
 
 Each xref:../languages.adoc[uProtocol Language Library]
@@ -420,8 +420,8 @@ The amount of time after which this response message should no longer be deliver
 
 |`commstatus`
 |xref:error_model.adoc#data-model-definition[UCode]
-|no
-a|The outcome of the RPC. No value or `UCode.OK` indicate successful invocation of the operation. All other values indicate that invocation was unsuccessful. The concrete value indicates the type of error that has occurred.
+|yes
+a|The outcome of the RPC. `UCode.Ok` indicates successful invocation of the operation. All other values indicate that invocation was unsuccessful. The concrete value indicates the type of error that has occurred. The message's payload may contain additional information about the error.
 
 |===
 

--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -30,7 +30,7 @@ message UAttributes {
     // A unique message identifier.
     UUID id = 1;
 
-    // This message's type which also indicates its purpose and determines contraints on the other properties.
+    // This message's type which also indicates its purpose and determines constraints on the other properties.
     UMessageType type = 2;
 
     // The origin (address) of this message.
@@ -46,16 +46,19 @@ message UAttributes {
     optional uint32 ttl = 6;
 
     // The service consumer's permission level.
+    // Declared as optional because only RPC Request messages may carry it.
     optional uint32 permission_level = 7;
 
-    // A UCode indicating an error that has occurred
-    // during the delivery of either an RPC Request or Response message.
+    // A code indicating an error that has occurred during a remote procedure call.
+    // This is mandatory for RPC Response messages only.
     optional UCode commstatus = 8;
 
-    // The identifier that a service consumer can use to correlate an RPC Repsonse message with its RPC Request.
-    UUID reqid = 9;
+    // The identifier that a service consumer can use to correlate an RPC Response message with its RPC Request.
+    // This is mandatory for RPC Request messages only.
+    optional UUID reqid = 9;
 
     // The service consumer's access token.
+    // Declared as optional because only RPC Request messages may carry it.
     optional string token = 10;
 
     // A tracing identifier to use for correlating messages across the system.

--- a/up-core-api/uprotocol/v1/ustatus.proto
+++ b/up-core-api/uprotocol/v1/ustatus.proto
@@ -22,7 +22,7 @@ option java_package = "org.eclipse.uprotocol.v1";
 option java_outer_classname = "UStatusProto";
 option java_multiple_files = true;
 
-// uProtocol Error model for all uProtocol APIs that is loosly based off
+// uProtocol Error model for all uProtocol APIs that is loosely based off
 // google.rpc.Status
 message UStatus {
   // The status code.
@@ -33,7 +33,7 @@ message UStatus {
   // details field, or localized by the client.
   optional string message = 2;
 
-  // A list of messages that carry the error details.  There is a common set of
+  // A list of messages that carry the error details. There is a common set of
   // message types for APIs to use.
   repeated google.protobuf.Any details = 3;
 }


### PR DESCRIPTION
* Updated the error model spec to make the `code` property mandatory for a UStatus.
* Updated the UAttributes spec to make the `commstatus` property mandatory for RPC Response messages.
* Adapted the proto3 files accordingly.