### PR TITLE
feat!: define unified payload encoding identity

### DIFF
--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -47,7 +47,7 @@ class UAttributes {
   requestId: UUID [0..1]
   token: String [0..1]
   traceparent: String [0..1]
-  payloadEncodingId: UInt32 [0..1]
+  payloadEncodingId: UInt16 [0..1]
 }
 
 class UMessageType {
@@ -173,26 +173,33 @@ The traceparent *MUST* either be empty or contain a value as defined by https://
 
 
 |`payloadEncodingId`
-|`UInt32`
+|`UInt16`
 |no
 |none
-a|The encoding of the message payload, represented by an entry identifier in the
-xref:#payload-encoding-registry[payload-encoding registry].
+a|The encoding of the message payload, represented by an identifier defined in
+the xref:#payload-encoding-registry[payload-encoding registry].
 
 [.specitem,oft-sid="dsn~up-attributes-payload-encoding-id~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
 --
-The property
+The property and the UMessage's `payload` field *MUST* either both be present or
+both be absent. A present zero-length `payload` field is a present payload.
 
-* *MUST NOT* contain a value if the message has no payload;
-* *MUST NOT* contain the reserved identifier `0`; and
-* if the message has a payload, *MUST* contain the registry entry identifier of
-  the payload's encoding unless the applicable transport binding defines the
-  encoding out of band.
+If present, the property
 
-If a message has a payload and does not contain this property, the applicable
-transport binding *MUST* define the payload encoding. A receiver *MUST* reject a
-payload if its encoding cannot be determined or if the receiver does not
-recognize the declared identifier.
+* *MUST* contain a value in the range `0x0000` to `0xDFFF` or `0xF000` to
+  `0xFFFF`; and
+* *MUST NOT* contain a value greater than `0xFFFF` or in the reserved range
+  `0xE000` to `0xEFFF`.
+
+Identifier `0x0000` indicates that a binding, service, or schema contract
+defines the concrete payload encoding. A component that needs to interpret such
+a payload *MUST* have that contract and *MUST NOT* infer the encoding from the
+payload data.
+
+Structural validation *MUST NOT* reject an otherwise valid identifier in the
+registry-assignment or private-use range merely because the component does not
+recognize or support it. A component that needs to interpret a payload *MUST*
+reject the payload if its encoding cannot be determined or is not supported.
 --
 
 |===
@@ -464,34 +471,83 @@ a|The outcome of the RPC. `UCode.Ok` indicates successful invocation of the oper
 [#payload-encoding-registry]
 == Payload-Encoding Registry
 
-The payload-encoding registry assigns an unsigned 32-bit identifier to each
-payload encoding. A `payloadEncodingId` value is an entry identifier from this
-registry.
+The payload-encoding registry defines an unsigned 16-bit identifier space for
+payload encoding identity. The identifier space is partitioned as follows:
 
-[.specitem,oft-sid="dsn~payload-encoding-registry~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
---
-* Identifier `0` is reserved and *MUST NOT* be used on the wire.
-* Identifiers `1`-`11` are assigned and *MUST NOT* be reassigned.
-* Identifiers `12` to `0x0FFF_FFFF` are available for registry assignments.
-* Identifiers `0x1000_0000` and above are private use: they are valid on the
-  wire, are never registered, and carry meaning only by deployment-level
-  agreement.
---
+* `0x0000` denotes an implicit encoding defined by an applicable binding,
+  service, or schema contract.
+* `0x0001` to `0xDFFF` are available for registry assignments.
+* `0xE000` to `0xEFFF` are reserved for future use and invalid on the wire.
+* `0xF000` to `0xFFFF` are private use. They are valid on the wire, are never
+  registered, and carry meaning only by deployment-level agreement.
+
+This is an independent uProtocol registry. Its identifiers do not reuse the
+numeric values of the IANA CoAP Content-Formats registry.
+
+A registry assignment is permanent and *MUST NOT* be reassigned. New
+assignments are made by changing the table below through the normal up-spec
+review process; changing the identifier-space partition is not required. Each
+assignment *MUST* provide a stable name, a precise description, a formal public
+specification, and a registered media type when one accurately identifies the
+encoding. Producers *MUST NOT* use an unassigned identifier.
+
+An identifier in the registry-assignment range remains structurally valid when
+a receiver's local copy of the registry does not contain it. This permits
+intermediaries and older implementations to preserve identifiers assigned by a
+newer specification without claiming support for decoding their payloads.
 
 .Payload-encoding registry
-[cols="1,3,3", options="header"]
+[cols="1,2,5,3,5", options="header"]
 |===
-|ID |Encoding |Media type
+|ID |Name |Description |Media type |Specification
 
-|1 |Protobuf, wrapped in `google.protobuf.Any` |`application/x-protobuf`
-|2 |Protobuf |`application/protobuf`
-|3 |JSON |`application/json`
-|4 |SOME/IP |`application/x-someip`
-|5 |SOME/IP TLV |`application/x-someip_tlv`
-|6 |Raw bytes |`application/octet-stream`
-|7 |UTF-8 text |`text/plain`
-|8 |Shared-memory reference |`application/x-shm`
-|9 |XCDR v2 (DDS serialization) |`application/vnd.uprotocol.xcdr-v2`
-|10 |Arrow IPC |`application/vnd.apache.arrow.stream`
-|11 |OMG IDL CDR |`application/vnd.uprotocol.omg-idl-cdr`
+|1
+|Protobuf Any
+|The Protobuf wire-format serialization of a `google.protobuf.Any`, including
+its type URL and serialized embedded message.
+|https://www.iana.org/assignments/media-types/application/protobuf[`application/protobuf`]
+|https://protobuf.dev/programming-guides/encoding/[Protobuf wire format] and
+https://protobuf.dev/reference/protobuf/google.protobuf/#any[`google.protobuf.Any`]
+
+|2
+|Protobuf
+|The Protobuf wire-format serialization of a message whose type is defined by
+the applicable service or schema contract.
+|https://www.iana.org/assignments/media-types/application/protobuf[`application/protobuf`]
+|https://protobuf.dev/programming-guides/encoding/[Protobuf wire format]
+
+|3
+|JSON
+|A JSON text encoded as UTF-8.
+|https://www.iana.org/assignments/media-types/application/json[`application/json`]
+|https://www.rfc-editor.org/rfc/rfc8259[RFC 8259]
+
+|4
+|SOME/IP
+|The SOME/IP serialization of parameters and data structures defined by the
+applicable service-interface contract.
+|None registered
+|https://some-ip.com/open-someip-specification/open_someip_specification_2025-12.pdf[Open SOME/IP Specification 2025-12, Section 5.4]
+
+|5
+|SOME/IP TLV
+|The SOME/IP serialization of parameters and data structures using the optional
+TLV encoding defined by the applicable service-interface contract.
+|None registered
+|https://www.autosar.org/fileadmin/standards/R25-11/FO/AUTOSAR_FO_PRS_SOMEIPProtocol.pdf[AUTOSAR SOME/IP Protocol Specification R25-11, Section 5.1.3.3]
+
+|6
+|Raw bytes
+|An arbitrary sequence of octets with semantics defined by the applicable
+service or schema contract.
+|https://www.iana.org/assignments/media-types/application/octet-stream[`application/octet-stream`]
+|https://www.rfc-editor.org/rfc/rfc2046#section-4.5.1[RFC 2046, Section 4.5.1]
+
+|7
+|UTF-8 text
+|A linear sequence of Unicode characters encoded as UTF-8, without content
+markup or format-specific interpretation.
+|https://www.iana.org/assignments/media-types/text/plain[`text/plain; charset=utf-8`]
+|https://www.rfc-editor.org/rfc/rfc3629[RFC 3629] and
+https://www.rfc-editor.org/rfc/rfc2046#section-4.1.3[RFC 2046, Section 4.1.3]
 |===

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -184,11 +184,15 @@ xref:#payload-encoding-registry[payload-encoding registry].
 The property
 
 * *MUST NOT* contain a value if the message has no payload;
-* *MUST* contain the registry entry identifier of the payload's encoding if the
-  message has a payload;
 * *MUST NOT* contain the reserved identifier `0`; and
-* if a receiver does not recognize the identifier, the receiver *MUST* reject
-  the payload rather than interpret it under an assumed encoding.
+* if the message has a payload, *MUST* contain the registry entry identifier of
+  the payload's encoding unless the applicable transport binding defines the
+  encoding out of band.
+
+If a message has a payload and does not contain this property, the applicable
+transport binding *MUST* define the payload encoding. A receiver *MUST* reject a
+payload if its encoding cannot be determined or if the receiver does not
+recognize the declared identifier.
 --
 
 |===
@@ -457,36 +461,27 @@ a|The outcome of the RPC. `UCode.Ok` indicates successful invocation of the oper
 
 |===
 
-[#payload-format]
-== Payload Format (superseded)
-
-The former Payload Format section is superseded by the
-xref:#payload-encoding-registry[Payload-Encoding Registry]. The eight formats it
-listed are registry entries `1`-`8` with unchanged numeric values and media
-types. The anchor is retained for inbound links.
-
 [#payload-encoding-registry]
 == Payload-Encoding Registry
 
-Payload encodings are identified by a single unsigned 32-bit entry identifier.
-The registry is the sole mechanism for describing a message payload's encoding.
+The payload-encoding registry assigns an unsigned 32-bit identifier to each
+payload encoding. A `payloadEncodingId` value is an entry identifier from this
+registry.
 
 [.specitem,oft-sid="dsn~payload-encoding-registry~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
 --
 * Identifier `0` is reserved and *MUST NOT* be used on the wire.
-* Identifiers `1`-`8` are permanently assigned to the entries below, preserving
-  the numeric values of the retired `UPayloadFormat` enum, and *MUST NOT* be
-  reassigned.
-* Identifiers `9` to `0x0FFF_FFFF` are assigned through this registry.
+* Identifiers `1`-`11` are assigned and *MUST NOT* be reassigned.
+* Identifiers `12` to `0x0FFF_FFFF` are available for registry assignments.
 * Identifiers `0x1000_0000` and above are private use: they are valid on the
   wire, are never registered, and carry meaning only by deployment-level
   agreement.
 --
 
-.Registered payload encodings
+.Payload-encoding registry
 [cols="1,3,3", options="header"]
 |===
-|ID |Entry |Media type
+|ID |Encoding |Media type
 
 |1 |Protobuf, wrapped in `google.protobuf.Any` |`application/x-protobuf`
 |2 |Protobuf |`application/protobuf`
@@ -496,7 +491,7 @@ The registry is the sole mechanism for describing a message payload's encoding.
 |6 |Raw bytes |`application/octet-stream`
 |7 |UTF-8 text |`text/plain`
 |8 |Shared-memory reference |`application/x-shm`
-|9 |XCDR v2 (DDS serialization) footnote:proposed[Proposed entry, pending registration alongside the corresponding wire-format specification.] |`application/vnd.uprotocol.xcdr-v2`
-|10 |Arrow IPC footnote:proposed[] |`application/vnd.apache.arrow.stream`
-|11 |OMG IDL CDR footnote:proposed[] |`application/vnd.uprotocol.omg-idl-cdr`
+|9 |XCDR v2 (DDS serialization) |`application/vnd.uprotocol.xcdr-v2`
+|10 |Arrow IPC |`application/vnd.apache.arrow.stream`
+|11 |OMG IDL CDR |`application/vnd.uprotocol.omg-idl-cdr`
 |===

--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -47,6 +47,7 @@ class UAttributes {
   requestId: UUID [0..1]
   token: String [0..1]
   traceparent: String [0..1]
+  payloadEncodingId: UInt32 [0..1]
 }
 
 class UMessageType {
@@ -68,22 +69,8 @@ class UPriority {
   CS6
 }
 
-class UPayloadFormat {
-  <<Enumeration>>
-  Unspecified
-  ProtobufWrappedInAny
-  Protobuf
-  Json
-  SomeIp
-  SomeIpTlv
-  Raw
-  Text
-  SHM
-}
-
 UAttributes o-- UMessageType : type
 UAttributes o-- UPriority : priority
-UAttributes o-- "0..1" UPayloadFormat : payloadFormat
 ----
 
 Each xref:../languages.adoc[uProtocol Language Library]
@@ -185,14 +172,23 @@ The traceparent *MUST* either be empty or contain a value as defined by https://
 --
 
 
-|`payloadFormat`
-|<<payload-format,UPayloadFormat>>
+|`payloadEncodingId`
+|`UInt32`
 |no
 |none
-a|The format of the payload (data).
-[.specitem,oft-sid="dsn~up-attributes-payload-format~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
+a|The encoding of the message payload, represented by an entry identifier in the
+xref:#payload-encoding-registry[payload-encoding registry].
+
+[.specitem,oft-sid="dsn~up-attributes-payload-encoding-id~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
 --
-The payload format *MUST* be empty if the message has no payload.
+The property
+
+* *MUST NOT* contain a value if the message has no payload;
+* *MUST* contain the registry entry identifier of the payload's encoding if the
+  message has a payload;
+* *MUST NOT* contain the reserved identifier `0`; and
+* if a receiver does not recognize the identifier, the receiver *MUST* reject
+  the payload rather than interpret it under an assumed encoding.
 --
 
 |===
@@ -462,54 +458,45 @@ a|The outcome of the RPC. `UCode.Ok` indicates successful invocation of the oper
 |===
 
 [#payload-format]
-== Payload Format
+== Payload Format (superseded)
 
-The following table provides an overview of the payload formats supported by uProtocol.
+The former Payload Format section is superseded by the
+xref:#payload-encoding-registry[Payload-Encoding Registry]. The eight formats it
+listed are registry entries `1`-`8` with unchanged numeric values and media
+types. The anchor is retained for inbound links.
 
-[%autowidth]
+[#payload-encoding-registry]
+== Payload-Encoding Registry
+
+Payload encodings are identified by a single unsigned 32-bit entry identifier.
+The registry is the sole mechanism for describing a message payload's encoding.
+
+[.specitem,oft-sid="dsn~payload-encoding-registry~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
+--
+* Identifier `0` is reserved and *MUST NOT* be used on the wire.
+* Identifiers `1`-`8` are permanently assigned to the entries below, preserving
+  the numeric values of the retired `UPayloadFormat` enum, and *MUST NOT* be
+  reassigned.
+* Identifiers `9` to `0x0FFF_FFFF` are assigned through this registry.
+* Identifiers `0x1000_0000` and above are private use: they are valid on the
+  wire, are never registered, and carry meaning only by deployment-level
+  agreement.
+--
+
+.Registered payload encodings
+[cols="1,3,3", options="header"]
 |===
-|UPayloadFormat |MIME Type |Payload encoding
+|ID |Entry |Media type
 
-| `Unspecified`
-| N/A
-| The payload format is unknown. Clients will need to have gained knowledge about the concrete encoding and semantics of the payload by means of an out-of-band mechanism.
-
-
-|`ProtobufWrappedInAny`
-|`application/x-protobuf`
-a|The network byte order serialization of a `google.protobuf.Any` structure that contains the payload itself along with the schema URI indicating the (protobuf) type of the payload.
-
-**Note:** Using this payload format allows receivers of messages to determine the type of the payload from the schema URI and deserialize it accordingly. However, it also adds some overhead to the message size due to the additional `google.protobuf.Any` wrapper.
-
-|`Protobuf`
-|https://www.iana.org/assignments/media-types/application/protobuf[application/protobuf]
-a|The network byte order serialization of the protobuf structure representing the payload data.
-
-**Note:** Using this payload format requires that receivers of messages know the type of the payload in advance, as it is not included in the message itself. This can be achieved through out-of-band mechanisms or by using a predefined schema.
-
-|`Json`
-|https://www.iana.org/assignments/media-types/application/json[application/json]
-|The network byte order UTF-8 encoding of a JSON structure representing the payload data.
-
-|`SomeIp`
-|`application/x-someip`
-|The network byte order serialization of SOME/IP payload data as defined in [Open SOME/IP Specification, Section 5.4](https://some-ip.com/open-someip-specification/open_someip_specification_2025-12.pdf).
-
-|`SomeIpTlv`
-|`application/x-someip_tlv`
-|The network byte order serialization of SOME/IP payload data using the (optional) TLV encoding as defined in [SOME/IP Protocol Specification, Section 5.1.3.3](https://www.autosar.org/fileadmin/standards/R25-11/FO/AUTOSAR_FO_PRS_SOMEIPProtocol.pdf).
-
-|`Raw`
-|https://www.iana.org/assignments/media-types/application/octet-stream[application/octet-stream]
-|A byte array representing the payload data.
-
-|`Text`
-|https://www.iana.org/assignments/media-types/text/plain[text/plain]
-|The network byte order UTF-8 encoding of a unicode string representing the payload data.
-
-|`SHM`
-|`application/x-shm`
-a|The network byte order address of a shared memory segment.
-
-**Note:** The `SHM` payload format is supposed to be used for payloads that are stored in a shared memory segment. The `payload` of the `UMessage` will contain the address of the shared memory segment, and the `payloadFormat` attribute will be set to `SHM`. The actual data in the shared memory segment is not part of the `UMessage` and is not transmitted over the network. The semantics of how to access and interpret the data in the shared memory segment is left to the application and is not defined by uProtocol.
+|1 |Protobuf, wrapped in `google.protobuf.Any` |`application/x-protobuf`
+|2 |Protobuf |`application/protobuf`
+|3 |JSON |`application/json`
+|4 |SOME/IP |`application/x-someip`
+|5 |SOME/IP TLV |`application/x-someip_tlv`
+|6 |Raw bytes |`application/octet-stream`
+|7 |UTF-8 text |`text/plain`
+|8 |Shared-memory reference |`application/x-shm`
+|9 |XCDR v2 (DDS serialization) footnote:proposed[Proposed entry, pending registration alongside the corresponding wire-format specification.] |`application/vnd.uprotocol.xcdr-v2`
+|10 |Arrow IPC footnote:proposed[] |`application/vnd.apache.arrow.stream`
+|11 |OMG IDL CDR footnote:proposed[] |`application/vnd.uprotocol.omg-idl-cdr`
 |===

--- a/basics/umessage.adoc
+++ b/basics/umessage.adoc
@@ -27,6 +27,10 @@ uProtocol entities communicate with each other by means of exchanging `UMessages
 
 A UMessage consists of xref:uattributes.adoc[UAttributes] holding the message's meta data and (optional) payload as shown in the class diagram below (using UML2 notation).
 
+Payload presence is determined by whether the optional `payload` field is
+explicitly set, not by the number of bytes it contains. An explicitly set
+zero-length byte sequence is therefore a present payload.
+
 .UMessage Data Model
 [#umessage-data-model]
 [mermaid]

--- a/up-core-api/uprotocol/core/udiscovery/v3/udiscovery.proto
+++ b/up-core-api/uprotocol/core/udiscovery/v3/udiscovery.proto
@@ -51,12 +51,11 @@ service uDiscovery {
   }
 
 
-  // Get information about one or more topics that is being served by a service
+  // Get information about one or more topics served by a service.
   //
-  // The API is used to fetch metadata about one or more topics (depending on what is passed in the UUri).
-  // Wildcard ue_id and/or resource_id can be used to fetch multiple metadata for multiple topics.  
-  // The UServiceTopic stores topic metadata such as the permission level, message name, payload format
-  // (how the message is encoded) and more.
+  // The UUri identifies the topics. Wildcards in ue_id or resource_id select
+  // multiple topics. UServiceTopic defines the topic identifier, topic name,
+  // message type, resources, and permission level.
   //
   rpc GetServiceTopics(GetServiceTopicsRequest) returns (GetServiceTopicsResponse) {
     option (uprotocol.method_id) = 2;

--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -65,11 +65,13 @@ message UAttributes {
     // Intended to be compatible with https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md
     optional string traceparent = 11;
 
-    // The payload encoding, given as an entry identifier in the uProtocol
-    // payload-encoding registry. This field is absent when the message carries
-    // no payload or when the transport binding defines the encoding out of
-    // band. Identifier 0 is reserved. Identifiers at or above 0x1000_0000 are
-    // private use and carry meaning only by deployment-level agreement.
+    // The payload encoding, given as a 16-bit identifier. This field and the
+    // UMessage payload field are either both present or both absent. Identifier
+    // 0 means that an applicable binding, service, or schema contract defines
+    // the encoding. Values from 0x0001 to 0xDFFF are registry assignments,
+    // 0xE000 to 0xEFFF are reserved and invalid on the wire, and 0xF000 to
+    // 0xFFFF are private use. The uint32 type is used because protobuf has no
+    // uint16 type; values greater than 0xFFFF are invalid.
     optional uint32 payload_encoding_id = 12;
 }
 

--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -65,8 +65,13 @@ message UAttributes {
     // Intended to be compatible with https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md
     optional string traceparent = 11;
 
-    // The format for the data stored in the UMessage.
-    UPayloadFormat payload_format = 12;
+    // The payload encoding, given as an entry identifier in the uProtocol
+    // payload-encoding registry. Absent when the message carries no payload.
+    // Identifiers 1-8 preserve the numeric values of the retired
+    // UPayloadFormat enum. Identifiers at or above 0x1000_0000 are private use:
+    // valid on the wire, never registered, and meaningful only by
+    // deployment-level agreement.
+    optional uint32 payload_encoding_id = 12;
 }
 
 
@@ -127,34 +132,4 @@ enum UPriority {
 
     // Network control such as Safety Critical
     UPRIORITY_CS6 = 7 [(uprotocol.ce_name) = "CS6"];
-}
-
-// The format for the data stored in the UMessage.
-enum UPayloadFormat {
-    // Payload format is unknown.
-    UPAYLOAD_FORMAT_UNSPECIFIED = 0;
-
-    // Payload is an Any protobuf message that contains the packed payload
-    UPAYLOAD_FORMAT_PROTOBUF_WRAPPED_IN_ANY = 1 [ (uprotocol.mime_type) = "application/x-protobuf" ];
-
-    // Protobuf serialization format
-    UPAYLOAD_FORMAT_PROTOBUF = 2 [ (uprotocol.mime_type) = "application/protobuf" ];
-
-    // JSON serialization format
-    UPAYLOAD_FORMAT_JSON = 3 [ (uprotocol.mime_type) = "application/json" ];
-
-    // Basic SOME/IP serialization format
-    UPAYLOAD_FORMAT_SOMEIP = 4 [ (uprotocol.mime_type) = "application/x-someip" ];
-
-    // SOME/IP TLV format
-    UPAYLOAD_FORMAT_SOMEIP_TLV = 5 [ (uprotocol.mime_type) = "application/x-someip_tlv" ];
-
-    // RAW (binary) format
-    UPAYLOAD_FORMAT_RAW = 6 [ (uprotocol.mime_type) = "application/octet-stream" ];
-
-    // Text format
-    UPAYLOAD_FORMAT_TEXT = 7 [ (uprotocol.mime_type) = "text/plain" ];
-
-    // Shared memory format
-    UPAYLOAD_FORMAT_SHM = 8 [ (uprotocol.mime_type) = "application/x-shm" ];
 }

--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -66,11 +66,10 @@ message UAttributes {
     optional string traceparent = 11;
 
     // The payload encoding, given as an entry identifier in the uProtocol
-    // payload-encoding registry. Absent when the message carries no payload.
-    // Identifiers 1-8 preserve the numeric values of the retired
-    // UPayloadFormat enum. Identifiers at or above 0x1000_0000 are private use:
-    // valid on the wire, never registered, and meaningful only by
-    // deployment-level agreement.
+    // payload-encoding registry. This field is absent when the message carries
+    // no payload or when the transport binding defines the encoding out of
+    // band. Identifier 0 is reserved. Identifiers at or above 0x1000_0000 are
+    // private use and carry meaning only by deployment-level agreement.
     optional uint32 payload_encoding_id = 12;
 }
 
@@ -79,10 +78,8 @@ message UAttributes {
 // Using the message type, validation can be performed to ensure transport
 // validity of the data in the {@link UAttributes}.
 //
-// The "up-" prefix used in the uprotocol.ce_name options has been introduced
-// to allow distinguishing between existing CloudEvents being exchanged by
-// legacy systems using a predecessor of Eclipse uProtocol and CloudEvents
-// conforming to the mapping rules defined in the Eclipse uProtocol specification.
+// The "up-" prefix in each uprotocol.ce_name value identifies the event as an
+// Eclipse uProtocol CloudEvent.
 enum UMessageType {
     // Unspecified message type
     UMESSAGE_TYPE_UNSPECIFIED = 0;

--- a/up-core-api/uprotocol/v1/umessage.proto
+++ b/up-core-api/uprotocol/v1/umessage.proto
@@ -29,6 +29,7 @@ message UMessage {
     // content and processing requirements.
     UAttributes attributes = 1;
 
-    // Message payload
+    // Message payload. Presence is independent of length, so an explicitly set
+    // zero-length byte sequence is a present payload.
     optional bytes payload = 2;
 }

--- a/up-l1/cloudevents.adoc
+++ b/up-l1/cloudevents.adoc
@@ -152,10 +152,15 @@ a|A code indicating an error that has occurred during the delivery of either an 
 |String
 |A tracing identifier to use for correlating messages across the system.
 
-|`payload_format`
+|`payload_encoding_id`
 |`pformat`
 |Integer
-|The value of the UPayloadFormat that is used to indicate the encoding of the payload (if any). The concrete mapping rules are defined in <<ce-formats>>.
+a|The xref:../basics/uattributes.adoc#payload-encoding-registry[payload-encoding
+registry] entry identifier.
+
+* If the CloudEvent contains payload data, `pformat` *MUST* contain the
+  payload-encoding identifier.
+* If the CloudEvent does not contain payload data, `pformat` *MUST* be absent.
 
 |===
 
@@ -164,7 +169,9 @@ a|A code indicating an error that has occurred during the delivery of either an 
 
 The sections below define the mapping of uPayload to CloudEvent attributes.
 
-NOTE: The custom `pformat` property is used to indicate the payload type instead of the standard `datacontenttype` property defined by CloudEvents. Its value is set to the integer value assigned to the link:../up-core-api/uprotocol/uattributes.proto[UPayloadFormat]. This helps to reduce the size of the resulting data structure.
+The `pformat` property carries the numeric payload-encoding identifier.
+CloudEvents `datacontenttype` does not carry uProtocol payload-encoding
+identity. Using the numeric identifier avoids transmitting a media-type string.
 
 ==== Mapping to CloudEvent Protobuf Format
 
@@ -174,47 +181,52 @@ This mapping *MUST* be used by uProtocol Transport Libraries which use the Proto
 
 [%autowidth]
 |===
-|UPayloadFormat |CE `pformat` |CE `dataschema` |CE Property to map Payload Data to
+|Payload-encoding ID |CE `pformat` |CE `dataschema` |CE Property to map Payload Data to
 
-|`Unspecified`
-|`-`
-|*MAY* be set to a URI-Reference identifying the schema that the data adheres to
-|`binary_data`
+|(absent)
+|(absent)
+|(absent)
+|No payload data property
 
-|`ProtobufWrappedInAny`
-|`0x01`
+|`1` (Protobuf in `Any`)
+|`1`
 |*MAY* be set to `type.googleapis.com/google.protobuf.Any`
 |`proto_data`
 
-|`Protobuf`
-|`0x02`
+|`2` (Protobuf)
+|`2`
 |*SHOULD* be set to the protobuf's type URL
 |`proto_data`
 
-|`Json`
-|`0x03`
+|`3` (JSON)
+|`3`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`text_data`
 
-|`SomeIp`
-|`0x04`
+|`4` (SOME/IP)
+|`4`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`binary_data`
 
-|`SomeIpTlv`
-|`0x05`
+|`5` (SOME/IP TLV)
+|`5`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`binary_data`
 
-|`Raw`
-|`0x06`
+|`6` (raw bytes)
+|`6`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`binary_data`
 
-|`Text`
-|`0x07`
+|`7` (UTF-8 text)
+|`7`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`text_data`
+
+|Any other valid identifier
+|The payload-encoding identifier
+|*MAY* be set to a URI-Reference identifying the schema that the data adheres to
+|`binary_data`
 
 |===
 
@@ -226,47 +238,52 @@ This mapping *MUST* be used by uProtocol Transport Libraries which use the JSON 
 
 [%autowidth]
 |===
-|UPayloadFormat |CE `pformat` |CE `dataschema` |CE Property to map Payload to
+|Payload-encoding ID |CE `pformat` |CE `dataschema` |CE Property to map Payload to
 
-|`Unspecified`
-|`-`
-|*MAY* be set to a URI-Reference identifying the schema that the data adheres to
-|`data_base64`
+|(absent)
+|(absent)
+|(absent)
+|No payload data property
 
-|`ProtobufWrappedInAny`
-|`0x01`
+|`1` (Protobuf in `Any`)
+|`1`
 |*MAY* be set to `type.googleapis.com/google.protobuf.Any`
 |`data_base64`
 
-|`Protobuf`
-|`0x02`
+|`2` (Protobuf)
+|`2`
 |*SHOULD* be set to the protobuf's type URL
 |`data_base64`
 
-|`Json`
-|`0x03`
+|`3` (JSON)
+|`3`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`data`
 
-|`SomeIp`
-|`0x04`
+|`4` (SOME/IP)
+|`4`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`data_base64`
 
-|`SomeIpTlv`
-|`0x05`
+|`5` (SOME/IP TLV)
+|`5`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`data_base64`
 
-|`Raw`
-|`0x06`
+|`6` (raw bytes)
+|`6`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`data_base64`
 
-|`Text`
-|`0x07`
+|`7` (UTF-8 text)
+|`7`
 |*MAY* be set to a URI-Reference identifying the schema that the data adheres to
 |`data`
+
+|Any other valid identifier
+|The payload-encoding identifier
+|*MAY* be set to a URI-Reference identifying the schema that the data adheres to
+|`data_base64`
 
 |===
 

--- a/up-l1/cloudevents.adoc
+++ b/up-l1/cloudevents.adoc
@@ -155,12 +155,17 @@ a|A code indicating an error that has occurred during the delivery of either an 
 |`payload_encoding_id`
 |`pformat`
 |Integer
-a|The xref:../basics/uattributes.adoc#payload-encoding-registry[payload-encoding
-registry] entry identifier.
+a|The identifier defined in the
+xref:../basics/uattributes.adoc#payload-encoding-registry[payload-encoding
+registry].
 
-* If the CloudEvent contains payload data, `pformat` *MUST* contain the
-  payload-encoding identifier.
-* If the CloudEvent does not contain payload data, `pformat` *MUST* be absent.
+* `pformat` *MUST* be present if and only if the CloudEvent payload data field
+  is present. A payload data field representing a zero-length byte sequence is
+  present.
+* When present, `pformat` *MUST* contain the payload-encoding identifier as an
+  integer, including `0` for an implicit encoding.
+* A receiver *MUST* reject a `pformat` value outside the valid identifier ranges
+  defined by the payload-encoding registry.
 
 |===
 
@@ -171,7 +176,9 @@ The sections below define the mapping of uPayload to CloudEvent attributes.
 
 The `pformat` property carries the numeric payload-encoding identifier.
 CloudEvents `datacontenttype` does not carry uProtocol payload-encoding
-identity. Using the numeric identifier avoids transmitting a media-type string.
+identity. It *MAY* be set to the registered media type for a registry entry when
+that media type accurately describes the payload, but it *MUST NOT* replace
+`pformat`. Using the numeric identifier avoids requiring a media-type string.
 
 ==== Mapping to CloudEvent Protobuf Format
 
@@ -187,6 +194,11 @@ This mapping *MUST* be used by uProtocol Transport Libraries which use the Proto
 |(absent)
 |(absent)
 |No payload data property
+
+|`0` (implicit)
+|`0`
+|*MAY* be set to a URI-Reference identifying the schema that the data adheres to
+|`binary_data`
 
 |`1` (Protobuf in `Any`)
 |`1`
@@ -244,6 +256,11 @@ This mapping *MUST* be used by uProtocol Transport Libraries which use the JSON 
 |(absent)
 |(absent)
 |No payload data property
+
+|`0` (implicit)
+|`0`
+|*MAY* be set to a URI-Reference identifying the schema that the data adheres to
+|`data_base64`
 
 |`1` (Protobuf in `Any`)
 |`1`

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -38,7 +38,10 @@ A uProtocol message consists of _UAttributes_ and optional payload. The followin
 
 [.specitem,oft-sid="dsn~up-transport-mqtt5-attributes-mapping~1",oft-covers="req~utransport-send-preserve-data~1",oft-needs="impl,utest",oft-tags="TransportLayerImpl"]
 --
-An MQTT 5 PUBLISH packet that is used to convey a uProtocol message *MUST* contain properties as defined in <<uAttributes Mapping to MQTT 5 PUBLISH Properties>> for those and only those of the UMessage's attributes which have a non-empty value.
+An MQTT 5 PUBLISH packet that is used to convey a uProtocol message *MUST*
+contain properties as defined in <<uAttributes Mapping to MQTT 5 PUBLISH Properties>>.
+Unless a mapping row defines presence explicitly, a property *MUST* be present
+if and only if the corresponding UMessage attribute has a non-empty value.
 --
 
 .uAttributes Mapping to MQTT 5 PUBLISH Properties
@@ -136,13 +139,22 @@ a| A tracing identifier to use for correlating messages across the system
 
 | _payload_encoding_id_
 | _Content Type_
-a| The xref:../basics/uattributes.adoc#payload-encoding-registry[payload-encoding
-registry] entry identifier
+a| The identifier defined in the
+xref:../basics/uattributes.adoc#payload-encoding-registry[payload-encoding
+registry]
 
-* If `_payload_encoding_id_` is present, _Content Type_ *MUST* be set to its
-  decimal string representation.
-* If `_payload_encoding_id_` is absent, _Content Type_ *MUST NOT* be set by this
-  mapping.
+* _Content Type_ *MUST* be present if and only if the PUBLISH packet represents
+  a present UMessage `payload` field. This includes a present zero-length
+  payload.
+* When present, _Content Type_ *MUST* be set to the identifier's decimal string
+  representation, including `0` for an implicit encoding.
+* When reconstructing a UMessage, the presence of _Content Type_ determines the
+  presence of its `payload` and `_payload_encoding_id_` fields. A receiver
+  *MUST* reject a _Content Type_ value that is not a decimal unsigned integer,
+  is greater than `65535`, or is in the reserved range `57344` to `61439`
+  (`0xE000` to `0xEFFF`).
+* If _Content Type_ is absent, the PUBLISH packet payload *MUST* be empty and
+  both UMessage fields *MUST* be absent.
 
 The numeric identifier minimizes the size of the PUBLISH packet.
 

--- a/up-l1/mqtt_5.adoc
+++ b/up-l1/mqtt_5.adoc
@@ -134,13 +134,17 @@ a| A tracing identifier to use for correlating messages across the system
 
 * *MUST* be set to the traceparent value.
 
-| _payload_format_
+| _payload_encoding_id_
 | _Content Type_
-a| The type of data contained in the message's payload
+a| The xref:../basics/uattributes.adoc#payload-encoding-registry[payload-encoding
+registry] entry identifier
 
-* *MUST* be set to the link:../up-core-api/uprotocol/v1/uattributes.proto[UPayloadFormat enum] integer value's decimal string representation.
+* If `_payload_encoding_id_` is present, _Content Type_ *MUST* be set to its
+  decimal string representation.
+* If `_payload_encoding_id_` is absent, _Content Type_ *MUST NOT* be set by this
+  mapping.
 
-Note that the enum's integer value is used instead of the _uprotocol.mime_type_ option's value in order to reduce the overall size of the PUBLISH packet.
+The numeric identifier minimizes the size of the PUBLISH packet.
 
 |===
 

--- a/up-l1/someip.adoc
+++ b/up-l1/someip.adoc
@@ -127,9 +127,11 @@ The following sections highlight the mapping of xref:../basics/uattributes.adoc[
 
 Check `ttl` xref:#note-ttl[NOTE] below.
 
-| payload_format | SOME/IP specification however does not have an equivalent field for xref:../basics/uattributes.adoc#payload-format[UPayloadFormat].
+| payload_encoding_id | SOME/IP does not provide a field for the xref:../basics/uattributes.adoc#payload-encoding-registry[payload-encoding identifier].
 
-It is assumed that the payload is serialized in the format that the other end knows how to deserialize (i.e. it is fixed per topic). As such, when converting between uProtocol and SOME/IP, the `payload_format` field *SHOULD* be ignored (left at the default or `UPAYLOAD_FORMAT_UNSPECIFIED`).
+The SOME/IP service/interface contract *MUST* define the payload encoding. A
+UMessage transported over SOME/IP *MUST NOT* contain `payload_encoding_id`. The
+binding *MUST* validate the payload against the configured encoding.
 |===
 
 
@@ -320,5 +322,3 @@ NOTE: handled by underlying SOME/IP library.
 === uDiscovery Translation
 
 *TODO:* _Pending uDiscovery v3 redesign_
-
-

--- a/up-l1/someip.adoc
+++ b/up-l1/someip.adoc
@@ -129,9 +129,17 @@ Check `ttl` xref:#note-ttl[NOTE] below.
 
 | payload_encoding_id | SOME/IP does not provide a field for the xref:../basics/uattributes.adoc#payload-encoding-registry[payload-encoding identifier].
 
-The SOME/IP service/interface contract *MUST* define the payload encoding. A
-UMessage transported over SOME/IP *MUST NOT* contain `payload_encoding_id`. The
-binding *MUST* validate the payload against the configured encoding.
+The SOME/IP service/interface contract *MUST* define the payload encoding and,
+when available, its corresponding uProtocol registry or private-use identifier.
+When mapping a payload-bearing UMessage to SOME/IP, the binding *MUST* verify
+that `payload_encoding_id` matches that contract.
+
+When reconstructing a payload-bearing UMessage from SOME/IP, the binding *MUST*
+set `payload_encoding_id` to the registered or private-use identifier defined by
+the contract. It *MUST* use `0` if the contract defines the concrete encoding
+without assigning it a registry or private-use identifier. The binding *MUST*
+reject the payload if its configured encoding cannot be established or does not
+match the message contract.
 |===
 
 

--- a/up-l3/udiscovery/v3/client.adoc
+++ b/up-l3/udiscovery/v3/client.adoc
@@ -90,7 +90,10 @@ The FindServices() API is used to find service instances matching search criteri
 
 === GetServiceTopics()
 
-The GetServiceTopics() API is used to fetch metadata about one or more topics (depending on what is passed in the UUri) so clients can know more metadata about the topic(s). Wildcard ue_id and/or resource_id can be used to fetch multiple `UServiceTopic` information. The `UServiceTopic` contains topic metadata such as the minimum permission level required to read from the topic, message name, payload format (how the message is encoded) and more.
+The GetServiceTopics() API returns metadata for topics matching a UUri.
+Wildcards in `ue_id` or `resource_id` select multiple topics. Each
+`UServiceTopic` defines the topic identifier, topic name, message type,
+resources, and minimum read permission.
 
 [.specitem,oft-sid="dsn~discovery-getservicetopics-error-notfound~1",oft-needs="impl,test"]
 --
@@ -125,4 +128,3 @@ Below are example use cases for the API when passed certain URIs (shown in strin
 
 
 NOTE: Please refer to the {discovery-proto-ref} for details of the UDiscovery Client APIs.
-


### PR DESCRIPTION
This replaces `UPayloadFormat` with one optional numeric `payload_encoding_id`, giving payload encodings an extensible, language-neutral identity. It also aligns the CloudEvents, MQTT 5, and SOME/IP mappings, and corrects the related uDiscovery documentation.
