### PR TITLE
Make payload format optional uattributes.proto

### DIFF
--- a/basics/uattributes.adoc
+++ b/basics/uattributes.adoc
@@ -190,9 +190,9 @@ The traceparent *MUST* either be empty or contain a value as defined by https://
 |no
 |none
 a|The format of the payload (data).
-[.specitem,oft-sid="dsn~up-attributes-payload-format~1",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
+[.specitem,oft-sid="dsn~up-attributes-payload-format~2",oft-needs="impl,utest",oft-tags="LanguageLibrary"]
 --
-The payload format *MUST* be empty if the message has no payload.
+The payload format *MUST* be empty if the message has no payload, otherwise it *MUST NOT* be empty.
 --
 
 |===

--- a/up-core-api/uprotocol/v1/uattributes.proto
+++ b/up-core-api/uprotocol/v1/uattributes.proto
@@ -65,8 +65,8 @@ message UAttributes {
     // Intended to be compatible with https://github.com/cloudevents/spec/blob/main/cloudevents/extensions/distributed-tracing.md
     optional string traceparent = 11;
 
-    // The format for the data stored in the UMessage.
-    UPayloadFormat payload_format = 12;
+    // The format of the data stored in the message's payload.
+    optional UPayloadFormat payload_format = 12;
 }
 
 


### PR DESCRIPTION
This commit makes the payload format optional in the uattributes.proto file. This is to make it consistent with the uattributes.adoc documentation: the payload format must be empty if the message has no payload, otherwise it must not be empty.

Fixes #327